### PR TITLE
Dispatch requests on method and path

### DIFF
--- a/spec/http_clj/application/hello_world_spec.clj
+++ b/spec/http_clj/application/hello_world_spec.clj
@@ -1,7 +1,6 @@
 (ns http-clj.application.hello-world-spec
   (:require [speclj.core :refer :all]
             [clj-http.client :as client]
-            [http-clj.mock :as mock]
             [http-clj.server :as s]
             [http-clj.application.hello-world :refer [app]])
   (:import java.util.concurrent.CountDownLatch))

--- a/spec/http_clj/application/hello_world_spec.clj
+++ b/spec/http_clj/application/hello_world_spec.clj
@@ -28,4 +28,7 @@
     (client/get "http://localhost:5000"))
 
   (it "contains 'Hello, world!'"
-    (should= "Hello, world!\r\n", (:body (client/get "http://localhost:5000")))))
+    (should= "Hello, world!", (:body (client/get "http://localhost:5000"))))
+
+  (it "/foo is a valid path"
+    (should= "Bar", (:body (client/get "http://localhost:5000/foo")))))

--- a/spec/http_clj/connection_spec.clj
+++ b/spec/http_clj/connection_spec.clj
@@ -1,7 +1,7 @@
 (ns http-clj.connection-spec
   (:require [speclj.core :refer :all]
             [http-clj.connection :refer [write readline create close]]
-            [http-clj.mock :as mock])
+            [http-clj.spec-helper.mock :as mock])
   (:import java.io.ByteArrayInputStream
            java.io.ByteArrayOutputStream))
 

--- a/spec/http_clj/lifecycle_spec.clj
+++ b/spec/http_clj/lifecycle_spec.clj
@@ -35,5 +35,5 @@
     (it "pushes a request through an application"
       (should-contain "Message body" (:written-to-connection (http @conn test-app))))
 
-    (it "it closes the connection"
-      (should= false (:open (http @conn test-app))))))
+    (it "leaves the connection open"
+      (should= true (:open (http @conn test-app))))))

--- a/spec/http_clj/lifecycle_spec.clj
+++ b/spec/http_clj/lifecycle_spec.clj
@@ -28,6 +28,7 @@
   (context "write-response"
     (it "writes the HTTP message to the connection"
       (let [conn (write-response {:body "Message body"
+                                  :status 200
                                   :conn (mock/connection)})]
         (should-contain "Message body" (:written-to-connection conn))
         (should-contain "HTTP/1.1 200 OK\r\n" (:written-to-connection conn)))))

--- a/spec/http_clj/lifecycle_spec.clj
+++ b/spec/http_clj/lifecycle_spec.clj
@@ -4,8 +4,7 @@
             [http-clj.request :as request]
             [http-clj.response :as response]
             [http-clj.spec-helper.request-generator :refer [GET]]
-            [http-clj.lifecycle :refer [request->response
-                                        write-response
+            [http-clj.lifecycle :refer [write-response
                                         http]]))
 
 (defn test-app [request]
@@ -16,12 +15,6 @@
   (with conn
     (-> (GET "/path" {"User-Agent" "Test Request" "Host" "www.example.com"})
         (mock/connection)))
-
-  (context "request->response"
-    (it "it returns a response"
-      (should= "Message body" (-> @conn
-                                  (request->response test-app)
-                                  (:body)))))
 
   (context "write-response"
     (it "writes the HTTP message to the connection"

--- a/spec/http_clj/lifecycle_spec.clj
+++ b/spec/http_clj/lifecycle_spec.clj
@@ -1,0 +1,40 @@
+(ns http-clj.lifecycle-spec
+  (:require [speclj.core :refer :all]
+            [http-clj.mock :as mock]
+            [http-clj.request :as request]
+            [http-clj.response :as response]
+            [http-clj.lifecycle :refer [request->response
+                                        write-response
+                                        http]]))
+
+
+(def request-message (str "GET /path HTTP/1.1\r\n"
+                          "User-Agent: Test Request\r\n"
+                          "Host: www.example.com\r\n"
+                          "\r\n"))
+
+(defn test-app [request]
+  (should= "GET" (:method request))
+  (response/create request "Message body"))
+
+(describe "the connection lifecycle"
+  (with conn (mock/connection request-message))
+  (context "request->response"
+    (it "it returns a response"
+      (should= "Message body" (-> @conn
+                                  (request->response test-app)
+                                  (:body)))))
+
+  (context "write-response"
+    (it "writes the HTTP message to the connection"
+      (let [conn (write-response {:body "Message body"
+                                  :conn (mock/connection)})]
+        (should-contain "Message body" (:written-to-connection conn))
+        (should-contain "HTTP/1.1 200 OK\r\n" (:written-to-connection conn)))))
+
+  (context "http"
+    (it "pushes a request through an application"
+      (should-contain "Message body" (:written-to-connection (http @conn test-app))))
+
+    (it "it closes the connection"
+      (should= false (:open (http @conn test-app))))))

--- a/spec/http_clj/lifecycle_spec.clj
+++ b/spec/http_clj/lifecycle_spec.clj
@@ -1,6 +1,6 @@
 (ns http-clj.lifecycle-spec
   (:require [speclj.core :refer :all]
-            [http-clj.mock :as mock]
+            [http-clj.spec-helper.mock :as mock]
             [http-clj.request :as request]
             [http-clj.response :as response]
             [http-clj.lifecycle :refer [request->response

--- a/spec/http_clj/lifecycle_spec.clj
+++ b/spec/http_clj/lifecycle_spec.clj
@@ -3,22 +3,20 @@
             [http-clj.spec-helper.mock :as mock]
             [http-clj.request :as request]
             [http-clj.response :as response]
+            [http-clj.spec-helper.request-generator :refer [GET]]
             [http-clj.lifecycle :refer [request->response
                                         write-response
                                         http]]))
-
-
-(def request-message (str "GET /path HTTP/1.1\r\n"
-                          "User-Agent: Test Request\r\n"
-                          "Host: www.example.com\r\n"
-                          "\r\n"))
 
 (defn test-app [request]
   (should= "GET" (:method request))
   (response/create request "Message body"))
 
 (describe "the connection lifecycle"
-  (with conn (mock/connection request-message))
+  (with conn
+    (-> (GET "/path" {"User-Agent" "Test Request" "Host" "www.example.com"})
+        (mock/connection)))
+
   (context "request->response"
     (it "it returns a response"
       (should= "Message body" (-> @conn

--- a/spec/http_clj/mock.clj
+++ b/spec/http_clj/mock.clj
@@ -6,6 +6,12 @@
   (:import java.io.ByteArrayInputStream
            java.io.ByteArrayOutputStream))
 
+
+(def request-message (str "GET /path HTTP/1.1\r\n"
+                          "User-Agent: Test Request\r\n"
+                          "Host: www.example.com\r\n"
+                          "\r\n"))
+
 (defn socket [input output]
   (let [connected? (atom true)]
     (proxy [java.net.Socket] []
@@ -39,7 +45,8 @@
   (readline [conn]
     (.readLine input))
 
-  (write [conn output] conn)
+  (write [conn text]
+    (assoc conn :written-to-connection text))
 
   (close [conn]
     (assoc conn :open false)))
@@ -61,7 +68,7 @@
 
   server/AcceptingServer
   (accept [server]
-    (connection)))
+    (connection request-message)))
 
 (defn server []
   (MockServer. false false))

--- a/spec/http_clj/request_spec.clj
+++ b/spec/http_clj/request_spec.clj
@@ -4,21 +4,61 @@
             [http-clj.mock :as mock]
             [clojure.java.io :as io]))
 
-(defn compose-input [& args]
-  (clojure.string/join "" (interleave args (repeat "\r\n"))))
+(def get-request (str "GET /file1 HTTP/1.1\r\n"
+                      "User-Agent: Test-request\r\n"
+                      "Host: www.example.com\r\n"
+                      "\r\n"))
 
-(describe "create"
-  (it "reads the connection input"
-    (should= ["Line 1"] (-> (compose-input "Line 1")
-                            (mock/connection)
-                            (request/create)
-                            (:input)))
+(def post-request (str "POST /file2 HTTP/1.0\r\n"
+                       "User-Agent: Test-request\r\n"
+                       "Host: www.example.us\r\n"
+                       "\r\n"
+                       "var=data"))
 
-    (should= ["Line 1" "Line 2"] (-> (compose-input "Line 1" "Line 2")
-                                     (mock/connection)
-                                     (request/create)
-                                     (:input))))
+(describe "request"
+  (with get-conn (mock/connection get-request))
+  (with post-conn (mock/connection post-request))
 
-  (it "attaches the connection to the request"
-    (let [conn (mock/connection)]
-    (should= conn (:conn (request/create conn))))))
+  (context "when created"
+    (it "has the connection"
+      (let [conn (mock/connection get-request)]
+        (should= conn (:conn (request/create conn)))))
+
+    (it "has the method"
+      (should= "GET" (:method (request/create @get-conn)))
+      (should= "POST" (:method (request/create @post-conn))))
+
+    (it "has the path"
+      (should= "/file1" (:path (request/create @get-conn)))
+      (should= "/file2" (:path (request/create @post-conn))))
+
+    (it "has the version"
+      (should= "HTTP/1.1" (:version (request/create @get-conn)))
+      (should= "HTTP/1.0" (:version (request/create @post-conn))))
+
+    (it "has headers"
+      (should= "www.example.com" (get-in
+                                   (request/create @get-conn)
+                                   [:headers "Host"]))
+      (should= "www.example.us" (get-in
+                                  (request/create @post-conn)
+                                  [:headers "Host"]))))
+  (context "parse-request-line"
+    (it "parses the method"
+      (should= "GET" (:method (request/parse-request-line @get-conn)))
+      (should= "POST" (:method (request/parse-request-line @post-conn))))
+
+    (it "parses the path"
+      (should= "/file1" (:path (request/parse-request-line @get-conn)))
+      (should= "/file2" (:path (request/parse-request-line @post-conn))))
+
+    (it "parses the version"
+      (should= "HTTP/1.1" (:version (request/parse-request-line @get-conn)))
+      (should= "HTTP/1.0" (:version (request/parse-request-line @post-conn)))))
+
+  (context "parse-headers"
+    (before (request/parse-request-line @get-conn))
+
+    (it "parses the headers"
+      (should= {"Host" "www.example.com" "User-Agent" "Test-request"}
+               (request/parse-headers @get-conn)))))

--- a/spec/http_clj/request_spec.clj
+++ b/spec/http_clj/request_spec.clj
@@ -1,7 +1,7 @@
 (ns http-clj.request-spec
   (:require [speclj.core :refer :all]
             [http-clj.request :as request]
-            [http-clj.mock :as mock]
+            [http-clj.spec-helper.mock :as mock]
             [clojure.java.io :as io]))
 
 (def get-request (str "GET /file1 HTTP/1.1\r\n"

--- a/spec/http_clj/response_spec.clj
+++ b/spec/http_clj/response_spec.clj
@@ -1,7 +1,7 @@
 (ns http-clj.response-spec
   (:require [speclj.core :refer :all]
             [http-clj.response :refer [create compose]]
-            [http-clj.mock :refer [connection]]))
+            [http-clj.spec-helper.mock :refer [connection]]))
 
 (def request {:conn (connection)})
 

--- a/spec/http_clj/response_spec.clj
+++ b/spec/http_clj/response_spec.clj
@@ -1,23 +1,33 @@
 (ns http-clj.response-spec
   (:require [speclj.core :refer :all]
             [http-clj.response :refer [create compose]]
-            [http-clj.spec-helper.mock :refer [connection]]))
+            [http-clj.spec-helper.mock :refer [connection]]
+            [clojure.string :as string]))
 
 (def request {:conn (connection)})
 
+(defn get-status-line [message]
+  (first (string/split message #"\r\n")))
+
 (describe "a response"
+  (with request {:conn (connection)})
+
   (context "when created"
     (it "has a body"
       (should= "Hello, world!" (:body (create request "Hello, world!"))))
+
+    (it "has a status code"
+      (should= 200 (:status (create request "Body")))
+      (should= 404 (:status (create request "Body" :status 404))))
 
     (it "has the connection"
       (should= (:conn request) (:conn (create request "")))))
 
   (context "when composed"
     (it "is a valid HTTP response"
-      (let [expected (str "HTTP/1.1 200 OK\r\n\r\n"
-                          "Hello, world!\r\n")]
-
+      (let [expected (str "HTTP/1.1 200 OK\r\n"
+                          "\r\n"
+                          "Hello, world!")]
         (should= expected (-> (create request "Hello, world!")
                               (compose)
                               (:message)))))
@@ -25,4 +35,16 @@
     (it "uses the body from the response"
       (should-contain "Message body" (-> (create request "Message body")
                                          (compose)
-                                         (:message))))))
+                                         (:message))))
+    (it "uses the status from the response"
+      (should-contain "404" (-> (create request "" :status 404)
+                                (compose)
+                                (:message))))
+
+    (it "has a status line for a GET request"
+      (let [{message :message} (compose (create @request "" :status 200))]
+        (should= "HTTP/1.1 200 OK" (get-status-line message))))
+
+    (it "has a status line for a GET request"
+      (let [{message :message} (compose (create @request "" :status 404))]
+        (should= "HTTP/1.1 404 Not Found" (get-status-line message))))))

--- a/spec/http_clj/router_spec.clj
+++ b/spec/http_clj/router_spec.clj
@@ -1,0 +1,29 @@
+(ns http-clj.router-spec
+  (:require [speclj.core :refer :all]
+            [http-clj.router :as router]))
+
+(describe "a router"
+  (with-stubs)
+  (with routes {["GET" "/a"] (stub :handler-a)
+                ["POST" "/b"] (stub :handler-b)})
+  (it "dispatches to handler-a"
+    (router/route {:method "GET" :path "/a"} @routes)
+    (should-not-have-invoked :handler-b)
+    (should-have-invoked :handler-a {:times 1}))
+
+  (it "dispatches to handler-b"
+    (router/route {:method "POST" :path "/b"} @routes)
+    (should-not-have-invoked :handler-a)
+    (should-have-invoked :handler-b {:times 1}))
+
+  (it "responds with not found there is no matching route"
+    (let [{status :status body :body} (router/route
+                                        {:method "GET" :path "/"} @routes)]
+      (should= 404 status)
+      (should-contain "Route not found" body)))
+
+  (it "will not find the handler if the path matches but the method does not"
+    (let [{status :status body :body} (router/route
+                                        {:method "GET" :path "/b"} @routes)]
+      (should= 404 status)
+      (should-contain "Route not found" body))))

--- a/spec/http_clj/server_spec.clj
+++ b/spec/http_clj/server_spec.clj
@@ -4,7 +4,7 @@
             [http-clj.connection :as connection]
             [http-clj.response :as response]
             [http-clj.lifecycle :as lifecycle]
-            [http-clj.mock :as mock]
+            [http-clj.spec-helper.mock :as mock]
             [com.stuartsierra.component :as component])
   (:import java.io.ByteArrayOutputStream))
 

--- a/spec/http_clj/server_spec.clj
+++ b/spec/http_clj/server_spec.clj
@@ -2,6 +2,8 @@
   (:require [speclj.core :refer :all]
             [http-clj.server :as s]
             [http-clj.connection :as connection]
+            [http-clj.response :as response]
+            [http-clj.lifecycle :as lifecycle]
             [http-clj.mock :as mock]
             [com.stuartsierra.component :as component])
   (:import java.io.ByteArrayOutputStream))
@@ -29,26 +31,23 @@
                                   (s/create)
                                   (s/accept))))))
 
-(defn test-app [conn]
-  (when (not (:open conn))
+(defn test-app [request]
+  (when (not (:open (:conn request)))
     (should-fail "The connection should be open"))
-  (assoc conn :app-called true))
+  (response/create request "App was called"))
 
 (describe "listen"
   (with server (mock/server))
-  (it "opens and closes connection"
-    (should= false (:open (s/listen @server identity))))
+  (it "kicks off the request/response lifecycle"
+    (should-invoke lifecycle/http {:times 1} (s/listen @server test-app))))
 
-  (it "the application is sandwiched between opening and closing the connection"
-    (should= true (:app-called (s/listen @server test-app)))))
-
-(defn interrupting-app [conn]
+(defn interrupting-app [request]
   (loop [count 3]
     (cond
       (zero? count) (.interrupt (Thread/currentThread))
       (neg? count) (should-fail "The loop should exit after interrupt")
       :else (recur (dec count))))
-  conn)
+  (response/create request ""))
 
 (describe "serve"
   (with server (mock/server))

--- a/spec/http_clj/server_spec.clj
+++ b/spec/http_clj/server_spec.clj
@@ -39,7 +39,12 @@
 (describe "listen"
   (with server (mock/server))
   (it "kicks off the request/response lifecycle"
-    (should-invoke lifecycle/http {:times 1} (s/listen @server test-app))))
+    (should-invoke lifecycle/http {:times 1 :return (mock/connection)}
+                   (s/listen @server test-app)))
+
+  (it "closes the connection"
+    (let [{open :open} (s/listen @server test-app)]
+      (should= false open))))
 
 (defn interrupting-app [request]
   (loop [count 3]

--- a/spec/http_clj/spec_helper/mock.clj
+++ b/spec/http_clj/spec_helper/mock.clj
@@ -2,15 +2,10 @@
   (:require [http-clj.connection :as connection]
             [http-clj.server :as server]
             [clojure.java.io :as io]
-            [com.stuartsierra.component :as component])
+            [com.stuartsierra.component :as component]
+            [http-clj.spec-helper.request-generator :refer [GET]])
   (:import java.io.ByteArrayInputStream
            java.io.ByteArrayOutputStream))
-
-
-(def request-message (str "GET /path HTTP/1.1\r\n"
-                          "User-Agent: Test Request\r\n"
-                          "Host: www.example.com\r\n"
-                          "\r\n"))
 
 (defn socket [input output]
   (let [connected? (atom true)]
@@ -68,7 +63,7 @@
 
   server/AcceptingServer
   (accept [server]
-    (connection request-message)))
+    (connection (GET "/" {"Host" "www.example.com"}))))
 
 (defn server []
   (MockServer. false false))

--- a/spec/http_clj/spec_helper/mock.clj
+++ b/spec/http_clj/spec_helper/mock.clj
@@ -1,4 +1,4 @@
-(ns http-clj.mock
+(ns http-clj.spec-helper.mock
   (:require [http-clj.connection :as connection]
             [http-clj.server :as server]
             [clojure.java.io :as io]

--- a/spec/http_clj/spec_helper/request_generator.clj
+++ b/spec/http_clj/spec_helper/request_generator.clj
@@ -1,0 +1,19 @@
+(ns http-clj.spec-helper.request-generator)
+
+(defn spread-headers [headers]
+  (reduce
+    (fn [string [key val]] (str string key ": " val "\r\n"))
+    ""
+    headers))
+
+(defn request [method path headers body]
+  (str method " " path " HTTP/1.1\r\n"
+       (spread-headers headers)
+       "\r\n"
+       body))
+
+(defn GET [path headers]
+  (request "GET" path headers ""))
+
+(defn POST [path headers body]
+  (request "POST" path headers body))

--- a/spec/http_clj/spec_helper/request_generator.clj
+++ b/spec/http_clj/spec_helper/request_generator.clj
@@ -1,14 +1,15 @@
 (ns http-clj.spec-helper.request-generator)
 
-(defn spread-headers [headers]
-  (reduce
-    (fn [string [key val]] (str string key ": " val "\r\n"))
-    ""
-    headers))
+(defn compose-header [header]
+  (let [[field-name field-value] header]
+    (str field-name ": " field-value "\r\n")))
+
+(defn compose-headers [headers]
+  (map compose-header headers))
 
 (defn request [method path headers body]
   (str method " " path " HTTP/1.1\r\n"
-       (spread-headers headers)
+       (apply str (compose-headers headers))
        "\r\n"
        body))
 

--- a/src/http_clj/application/hello_world.clj
+++ b/src/http_clj/application/hello_world.clj
@@ -1,9 +1,19 @@
 (ns http-clj.application.hello-world
   (:require [http-clj.response :as response]
+            [http-clj.router :refer [route]]
             [http-clj.server :refer [run]]))
 
-(defn app [request]
+(defn hello-world [request]
   (response/create request "Hello, world!"))
+
+(defn foo [request]
+  (response/create request "Bar"))
+
+(defn app [request]
+  (route
+    request
+    {["GET" "/"] hello-world
+     ["GET" "/foo"] foo}))
 
 (defn -main [& args]
   (run app 5000))

--- a/src/http_clj/application/hello_world.clj
+++ b/src/http_clj/application/hello_world.clj
@@ -1,17 +1,9 @@
 (ns http-clj.application.hello-world
   (:require [http-clj.response :as response]
-            [http-clj.request :as request]
-            [http-clj.connection :as connection]
             [http-clj.server :refer [run]]))
 
-(defn hello-world [request]
+(defn app [request]
   (response/create request "Hello, world!"))
-
-(defn app [conn]
-  (connection/write conn (-> (request/create conn)
-                             (hello-world)
-                             (response/compose)
-                             (:message))))
 
 (defn -main [& args]
   (run app 5000))

--- a/src/http_clj/lifecycle.clj
+++ b/src/http_clj/lifecycle.clj
@@ -17,5 +17,4 @@
 (defn http [conn app]
   (-> conn
       (request->response app)
-      write-response
-      connection/close))
+      write-response))

--- a/src/http_clj/lifecycle.clj
+++ b/src/http_clj/lifecycle.clj
@@ -1,0 +1,21 @@
+(ns http-clj.lifecycle
+  (:require [http-clj.request :refer [create]]
+            [http-clj.response :as response]
+            [http-clj.connection :as connection]))
+
+(defn request->response [conn app]
+  (-> conn
+      (create)
+      (app)))
+
+(defn write-response [resp]
+  (->> resp
+      (response/compose)
+      (:message)
+      (connection/write (:conn resp))))
+
+(defn http [conn app]
+  (-> conn
+      (request->response app)
+      (write-response)
+      (connection/close)))

--- a/src/http_clj/lifecycle.clj
+++ b/src/http_clj/lifecycle.clj
@@ -5,17 +5,17 @@
 
 (defn request->response [conn app]
   (-> conn
-      (create)
-      (app)))
+      create
+      app))
 
 (defn write-response [resp]
   (->> resp
-      (response/compose)
-      (:message)
+      response/compose
+      :message
       (connection/write (:conn resp))))
 
 (defn http [conn app]
   (-> conn
       (request->response app)
-      (write-response)
-      (connection/close)))
+      write-response
+      connection/close))

--- a/src/http_clj/lifecycle.clj
+++ b/src/http_clj/lifecycle.clj
@@ -3,11 +3,6 @@
             [http-clj.response :as response]
             [http-clj.connection :as connection]))
 
-(defn request->response [conn app]
-  (-> conn
-      create
-      app))
-
 (defn write-response [resp]
   (->> resp
       response/compose
@@ -16,5 +11,6 @@
 
 (defn http [conn app]
   (-> conn
-      (request->response app)
+      create
+      app
       write-response))

--- a/src/http_clj/request.clj
+++ b/src/http_clj/request.clj
@@ -9,8 +9,8 @@
 
 (defn parse-request-line [conn]
   (->> conn
-       (split-request-line)
-       (zipmap '(:method :path :version))))
+       split-request-line
+       (zipmap [:method :path :version])))
 
 (defn- parse-header [header]
   (let [[field-name field-value] (string/split header #":")]
@@ -32,5 +32,5 @@
 
 (defn create [conn]
   (-> {:conn conn}
-      (attach-request-line)
-      (attach-headers)))
+      attach-request-line
+      attach-headers))

--- a/src/http_clj/request.clj
+++ b/src/http_clj/request.clj
@@ -1,13 +1,36 @@
 (ns http-clj.request
-  (:require [http-clj.connection :as connection]))
+  (:require [http-clj.connection :as connection]
+            [clojure.string :as string]))
 
-(defn read-all [conn]
-  (loop [conn conn lines []]
-    (let [line (connection/readline conn)]
-      (if (empty? line)
-        lines
-        (recur conn (conj lines line))))))
+(defn- split-request-line [conn]
+  (-> conn
+      (connection/readline)
+      (string/split #" ")))
+
+(defn parse-request-line [conn]
+  (->> conn
+       (split-request-line)
+       (zipmap '(:method :path :version))))
+
+(defn- parse-header [header]
+  (let [[field-name field-value] (string/split header #":")]
+    {(string/trim field-name)
+     (string/trim field-value)}))
+
+(defn parse-headers [conn]
+  (loop [conn conn headers {}]
+    (let [header (connection/readline conn)]
+      (if (empty? header)
+        headers
+        (recur conn (merge headers (parse-header header)))))))
+
+(defn- attach-request-line [request]
+  (merge request (parse-request-line (:conn request))))
+
+(defn- attach-headers [request]
+  (assoc request :headers (parse-headers (:conn request))))
 
 (defn create [conn]
-  {:input (read-all conn)
-   :conn conn})
+  (-> {:conn conn}
+      (attach-request-line)
+      (attach-headers)))

--- a/src/http_clj/response.clj
+++ b/src/http_clj/response.clj
@@ -1,11 +1,27 @@
-(ns http-clj.response)
+(ns http-clj.response
+  (:require [clojure.string :as string]))
 
-(defn create [request body]
+(defn create [request body & {:keys [status]
+                              :or {status 200}}]
   {:body body
+   :status status
    :conn (:conn request)})
 
+(def reasons
+  {200 "OK"
+   404 "Not Found"})
+
+(defn reason-for [status]
+  (get reasons status))
+
+(defn compose-status-line [status]
+  (let [version "HTTP/1.1"
+        status status
+        reason (reason-for status)]
+  (string/join " " [version status reason])))
+
 (defn compose [resp]
-  (assoc resp :message (str "HTTP/1.1 200 OK\r\n"
+  (let [{status :status body :body} resp]
+  (assoc resp :message (str (compose-status-line status) "\r\n"
                             "\r\n"
-                            (:body resp)
-                            "\r\n")))
+                            body))))

--- a/src/http_clj/response.clj
+++ b/src/http_clj/response.clj
@@ -18,10 +18,10 @@
   (let [version "HTTP/1.1"
         status status
         reason (reason-for status)]
-  (string/join " " [version status reason])))
+    (string/join " " [version status reason])))
 
 (defn compose [resp]
   (let [{status :status body :body} resp]
-  (assoc resp :message (str (compose-status-line status) "\r\n"
-                            "\r\n"
-                            body))))
+    (assoc resp :message (str (compose-status-line status) "\r\n"
+                              "\r\n"
+                              body))))

--- a/src/http_clj/router.clj
+++ b/src/http_clj/router.clj
@@ -1,0 +1,10 @@
+(ns http-clj.router
+  (:require [http-clj.response :as response]))
+
+(defn- route-not-found [request]
+  (response/create request "Route not found" :status 404))
+
+(defn route [request routes]
+  (let [{method :method path :path} request
+        handler (get routes [method path] route-not-found)]
+    (handler request)))

--- a/src/http_clj/server.clj
+++ b/src/http_clj/server.clj
@@ -31,8 +31,10 @@
   (map->Server {:server-socket server-socket}))
 
 (defn listen [server app]
-  (-> (accept server)
-      (lifecycle/http app)))
+  (-> server
+      accept
+      (lifecycle/http app)
+      connection/close))
 
 (defn- open-latch [latch]
   (.countDown latch))

--- a/src/http_clj/server.clj
+++ b/src/http_clj/server.clj
@@ -1,6 +1,7 @@
 (ns http-clj.server
   (:require [com.stuartsierra.component :as component]
-            [http-clj.connection :as connection])
+            [http-clj.connection :as connection]
+            [http-clj.lifecycle :as lifecycle])
   (:import java.net.ServerSocket
            java.util.concurrent.CountDownLatch))
 
@@ -31,8 +32,7 @@
 
 (defn listen [server app]
   (-> (accept server)
-      (app)
-      (connection/close)))
+      (lifecycle/http app)))
 
 (defn- open-latch [latch]
   (.countDown latch))


### PR DESCRIPTION
This adds a router which allows an application to route requests to different handlers based on the method and path of the request.

To make way for this, I pushed the request creation and response writing code into the `lifecycle` namespace. Now `http-clj.server/listen` passes its connection to the `http-clj.lifecycle/http`, which in turn calls the application.

Completes story 19.
