### PR TITLE
Refactor request parsing

### DIFF
--- a/spec/http_clj/request/parser_spec.clj
+++ b/spec/http_clj/request/parser_spec.clj
@@ -6,33 +6,33 @@
             [http-clj.spec-helper.request-generator :refer [GET POST]]))
 
 (describe "request.parser"
-  (with get-conn
-    (mock/connection
+  (with get-request
+   {:conn  (mock/connection
       (GET "/file1"
-           {"Host" "www.example.com" "User-Agent" "Test-request"})))
+           {"Host" "www.example.com" "User-Agent" "Test-request"}))})
 
-  (with post-conn
-    (mock/connection
-      (POST "/file2"
-            {"Host" "www.example.us" "User-Agent" "Test-request"}
-            "var=data")))
+  (with post-request
+    {:conn (mock/connection
+             (POST "/file2"
+                   {"Host" "www.example.us" "User-Agent" "Test-request"}
+                   "var=data"))})
 
-  (context "parse-request-line"
-    (it "parses the method"
-      (should= "GET" (:method (parser/request-line @get-conn)))
-      (should= "POST" (:method (parser/request-line @post-conn))))
+     (context "parse-request-line"
+       (it "parses the method"
+         (should= "GET" (:method (parser/request-line @get-request)))
+         (should= "POST" (:method (parser/request-line @post-request))))
 
-    (it "parses the path"
-      (should= "/file1" (:path (parser/request-line @get-conn)))
-      (should= "/file2" (:path (parser/request-line @post-conn))))
+       (it "parses the path"
+         (should= "/file1" (:path (parser/request-line @get-request)))
+         (should= "/file2" (:path (parser/request-line @post-request))))
 
-    (it "parses the version"
-      (should= "HTTP/1.1" (:version (parser/request-line @get-conn)))
-      (should= "HTTP/1.1" (:version (parser/request-line @post-conn)))))
+       (it "parses the version"
+         (should= "HTTP/1.1" (:version (parser/request-line @get-request)))
+         (should= "HTTP/1.1" (:version (parser/request-line @post-request)))))
 
-  (context "parse-headers"
-    (before (parser/request-line @get-conn))
+     (context "parse-headers"
+       (before (parser/request-line @get-request))
 
-    (it "parses the headers"
-      (should= {"Host" "www.example.com" "User-Agent" "Test-request"}
-               (parser/headers @get-conn)))))
+       (it "parses the headers"
+         (should= {"Host" "www.example.com" "User-Agent" "Test-request"}
+                  (parser/headers @get-request)))))

--- a/spec/http_clj/request/parser_spec.clj
+++ b/spec/http_clj/request/parser_spec.clj
@@ -1,0 +1,38 @@
+(ns http-clj.request.parser-spec
+  (:require [speclj.core :refer :all]
+            [http-clj.request :as request]
+            [http-clj.request.parser :as parser]
+            [http-clj.spec-helper.mock :as mock]
+            [http-clj.spec-helper.request-generator :refer [GET POST]]))
+
+(describe "request.parser"
+  (with get-conn
+    (mock/connection
+      (GET "/file1"
+           {"Host" "www.example.com" "User-Agent" "Test-request"})))
+
+  (with post-conn
+    (mock/connection
+      (POST "/file2"
+            {"Host" "www.example.us" "User-Agent" "Test-request"}
+            "var=data")))
+
+  (context "parse-request-line"
+    (it "parses the method"
+      (should= "GET" (:method (parser/request-line @get-conn)))
+      (should= "POST" (:method (parser/request-line @post-conn))))
+
+    (it "parses the path"
+      (should= "/file1" (:path (parser/request-line @get-conn)))
+      (should= "/file2" (:path (parser/request-line @post-conn))))
+
+    (it "parses the version"
+      (should= "HTTP/1.1" (:version (parser/request-line @get-conn)))
+      (should= "HTTP/1.1" (:version (parser/request-line @post-conn)))))
+
+  (context "parse-headers"
+    (before (parser/request-line @get-conn))
+
+    (it "parses the headers"
+      (should= {"Host" "www.example.com" "User-Agent" "Test-request"}
+               (parser/headers @get-conn)))))

--- a/spec/http_clj/request_spec.clj
+++ b/spec/http_clj/request_spec.clj
@@ -37,24 +37,4 @@
                (get-in (request/create @get-conn) [:headers "Host"]))
 
       (should= "www.example.us"
-               (get-in (request/create @post-conn) [:headers "Host"]))))
-
-  (context "parse-request-line"
-    (it "parses the method"
-      (should= "GET" (:method (request/parse-request-line @get-conn)))
-      (should= "POST" (:method (request/parse-request-line @post-conn))))
-
-    (it "parses the path"
-      (should= "/file1" (:path (request/parse-request-line @get-conn)))
-      (should= "/file2" (:path (request/parse-request-line @post-conn))))
-
-    (it "parses the version"
-      (should= "HTTP/1.1" (:version (request/parse-request-line @get-conn)))
-      (should= "HTTP/1.1" (:version (request/parse-request-line @post-conn)))))
-
-  (context "parse-headers"
-    (before (request/parse-request-line @get-conn))
-
-    (it "parses the headers"
-      (should= {"Host" "www.example.com" "User-Agent" "Test-request"}
-               (request/parse-headers @get-conn)))))
+               (get-in (request/create @post-conn) [:headers "Host"])))))

--- a/src/http_clj/request.clj
+++ b/src/http_clj/request.clj
@@ -5,10 +5,10 @@
             [http-clj.request.parser :as parser]))
 
 (defn- attach-request-line [request]
-  (merge request (parser/request-line (:conn request))))
+  (merge request (parser/request-line request)))
 
 (defn- attach-headers [request]
-  (assoc request :headers (parser/headers (:conn request))))
+  (assoc request :headers (parser/headers request)))
 
 (defn create [conn]
    (-> {:conn conn}

--- a/src/http_clj/request.clj
+++ b/src/http_clj/request.clj
@@ -1,35 +1,14 @@
 (ns http-clj.request
   (:require [http-clj.connection :as connection]
             [http-clj.logging :as logging]
-            [clojure.string :as string]))
-
-(defn- split-request-line [conn]
-  (-> conn
-      (connection/readline)
-      (string/split #" ")))
-
-(defn parse-request-line [conn]
-  (->> conn
-       split-request-line
-       (zipmap [:method :path :version])))
-
-(defn- parse-header [header]
-  (let [[field-name field-value] (string/split header #":")]
-    {(string/trim field-name)
-     (string/trim field-value)}))
-
-(defn parse-headers [conn]
-  (loop [conn conn headers {}]
-    (let [header (connection/readline conn)]
-      (if (empty? header)
-        headers
-        (recur conn (merge headers (parse-header header)))))))
+            [clojure.string :as string]
+            [http-clj.request.parser :as parser]))
 
 (defn- attach-request-line [request]
-  (merge request (parse-request-line (:conn request))))
+  (merge request (parser/request-line (:conn request))))
 
 (defn- attach-headers [request]
-  (assoc request :headers (parse-headers (:conn request))))
+  (assoc request :headers (parser/headers (:conn request))))
 
 (defn create [conn]
    (-> {:conn conn}

--- a/src/http_clj/request/parser.clj
+++ b/src/http_clj/request/parser.clj
@@ -7,8 +7,8 @@
       (connection/readline)
       (string/split #" ")))
 
-(defn request-line [conn]
-  (->> conn
+(defn request-line [request]
+  (->> (:conn request)
        split-request-line
        (zipmap [:method :path :version])))
 
@@ -17,8 +17,8 @@
     {(string/trim field-name)
      (string/trim field-value)}))
 
-(defn headers [conn]
-  (loop [conn conn headers {}]
+(defn headers [request]
+  (loop [conn (:conn request) headers {}]
     (let [header (connection/readline conn)]
       (if (empty? header)
         headers

--- a/src/http_clj/request/parser.clj
+++ b/src/http_clj/request/parser.clj
@@ -1,0 +1,25 @@
+(ns http-clj.request.parser
+  (:require [http-clj.connection :as connection]
+            [clojure.string :as string]))
+
+(defn- split-request-line [conn]
+  (-> conn
+      (connection/readline)
+      (string/split #" ")))
+
+(defn request-line [conn]
+  (->> conn
+       split-request-line
+       (zipmap [:method :path :version])))
+
+(defn- parse-header [header]
+  (let [[field-name field-value] (string/split header #":")]
+    {(string/trim field-name)
+     (string/trim field-value)}))
+
+(defn headers [conn]
+  (loop [conn conn headers {}]
+    (let [header (connection/readline conn)]
+      (if (empty? header)
+        headers
+        (recur conn (merge headers (parse-header header)))))))


### PR DESCRIPTION
This strips out the request parsing code from `http-clj.request` and puts it in a separate namespace. Additionally, the parsers now take a request maps instead of a `Connection`
