### PR TITLE
Disallow methods

### DIFF
--- a/spec/http_clj/app/cob_spec/handlers_spec.clj
+++ b/spec/http_clj/app/cob_spec/handlers_spec.clj
@@ -5,16 +5,16 @@
   (:import java.io.ByteArrayOutputStream))
 
 (describe "handlers"
-  (context "fallback"
+  (context "static"
     (with dir "resources/static/")
     (it "responds with a listing if directory"
-      (should-contain "image.gif" (:body (fallback {:path "/"} @dir))))
+      (should-contain "image.gif" (:body (static {:path "/"} @dir))))
 
     (it "responds with a file if it is a file"
-      (should-contain "File contents" (String. (:body (fallback {:path "/file.txt"} @dir)))))
+      (should-contain "File contents" (String. (:body (static {:path "/file.txt"} @dir)))))
 
     (it "responds with 404 if a file is not found"
-      (should= 404 (:status (fallback {:path "/file-that-does-not-exist.txt"} @dir)))))
+      (should= 404 (:status (static {:path "/file-that-does-not-exist.txt"} @dir)))))
 
   (context "log"
     (with output (ByteArrayOutputStream.))

--- a/spec/http_clj/request_handler_spec.clj
+++ b/spec/http_clj/request_handler_spec.clj
@@ -41,6 +41,7 @@
   (context "method-not-allowed"
     (it "responds with status code 405"
       (should= 405 (:status (handler/method-not-allowed {}))))
+
     (it "has Method Not Allowed in the body"
       (should= "Method Not Allowed" (:body (handler/method-not-allowed {})))))
 

--- a/spec/http_clj/request_handler_spec.clj
+++ b/spec/http_clj/request_handler_spec.clj
@@ -38,6 +38,12 @@
     (it "has Not Found in the body"
       (should= "Not Found" (:body (handler/not-found {})))))
 
+  (context "method-not-allowed"
+    (it "responds with status code 405"
+      (should= 405 (:status (handler/method-not-allowed {}))))
+    (it "has Method Not Allowed in the body"
+      (should= "Method Not Allowed" (:body (handler/method-not-allowed {})))))
+
   (context "file"
     (with test-path "/tmp/http-clj-test-file-handler")
     (with test-data "Some content")

--- a/spec/http_clj/router_spec.clj
+++ b/spec/http_clj/router_spec.clj
@@ -6,8 +6,8 @@
 
 (describe "a router"
   (with-stubs)
-  (with routes {["GET" "/a"] (stub :handler-a)
-                ["POST" "/b"] (stub :handler-b)})
+  (with routes [["GET" "/a" (stub :handler-a)]
+                ["POST" "/b" (stub :handler-b)]])
   (it "dispatches to handler-a"
     (router/route {:method "GET" :path "/a"} @routes)
     (should-not-have-invoked :handler-b)

--- a/spec/http_clj/router_spec.clj
+++ b/spec/http_clj/router_spec.clj
@@ -38,8 +38,7 @@
 
 (describe "choose-handler"
   (with routes [{:path "/a" :handlers {"GET" :handler-get-a "POST" :handler-post-a}}
-                {:path "/b" :handlers {"HEAD" :handler-head-b "GET" :handler-get-b}}
-                ])
+                {:path "/b" :handlers {"HEAD" :handler-head-b "GET" :handler-get-b}}])
 
   (it "chooses the get handler"
     (let [request {:method "GET" :path "/a"}]

--- a/src/http_clj/app/cob_spec.clj
+++ b/src/http_clj/app/cob_spec.clj
@@ -13,8 +13,8 @@
 (defn- cob-spec [request directory]
   (route
     request
-    [["GET" "/log" #(handlers/log % log)]
-     ["GET" #"/.*" #(handlers/static % directory)]]))
+    [{:path "/log" :handlers {"GET" #(handlers/log % log)}}
+     {:path #"/.*" :handlers {"GET" #(handlers/static % directory)}}]))
 
 (defn app [directory]
   {:entrypoint #(cob-spec % directory)

--- a/src/http_clj/app/cob_spec.clj
+++ b/src/http_clj/app/cob_spec.clj
@@ -13,7 +13,7 @@
 (defn- cob-spec [request directory]
   (route
     request
-    {["GET" "/log"] #(handlers/log % log)}
+    [["GET" "/log" #(handlers/log % log)]]
     :fallback #(handlers/fallback % directory)))
 
 (defn app [directory]

--- a/src/http_clj/app/cob_spec.clj
+++ b/src/http_clj/app/cob_spec.clj
@@ -13,8 +13,8 @@
 (defn- cob-spec [request directory]
   (route
     request
-    [["GET" "/log" #(handlers/log % log)]]
-    :fallback #(handlers/fallback % directory)))
+    [["GET" "/log" #(handlers/log % log)]
+     ["GET" #"/.*" #(handlers/static % directory)]]))
 
 (defn app [directory]
   {:entrypoint #(cob-spec % directory)

--- a/src/http_clj/app/cob_spec/handlers.clj
+++ b/src/http_clj/app/cob_spec/handlers.clj
@@ -3,7 +3,7 @@
             [http-clj.file :as file-helper]
             [http-clj.response :as response]))
 
-(defn fallback [request directory]
+(defn static [request directory]
   (let [file (file-helper/resolve directory (:path request))]
     (cond (.isDirectory file) (handler/directory request file)
           (.exists file) (handler/file request file)

--- a/src/http_clj/request_handler.clj
+++ b/src/http_clj/request_handler.clj
@@ -12,6 +12,9 @@
 (defn not-found [request]
   (response/create request "Not Found" :status 404))
 
+(defn method-not-allowed [request]
+  (response/create request "Method Not Allowed" :status 405))
+
 (defn file
   ([request io-file] ((file (.getPath io-file)) request))
   ([path]

--- a/src/http_clj/router.clj
+++ b/src/http_clj/router.clj
@@ -2,8 +2,14 @@
   (:require [http-clj.response :as response]
             [http-clj.request-handler :as handler]))
 
+(defn- find-route [{method :method path :path} routes]
+  (first
+    (filter
+      #(and (= (first %1) method) (= (second %1) path))
+      routes)))
+
 (defn route [request routes & {:keys [fallback]
                                :or {fallback handler/not-found}}]
-  (let [{method :method path :path} request
-        handler (get routes [method path] fallback)]
+  (let [fallback-route [nil nil fallback]
+        [_ _ handler] (or (find-route request routes) fallback-route)]
     (handler request)))

--- a/src/http_clj/router.clj
+++ b/src/http_clj/router.clj
@@ -1,9 +1,8 @@
 (ns http-clj.router
-  (:require [http-clj.response :as response]
-            [http-clj.request-handler :as handler]))
+  (:require [http-clj.request-handler :as handler]))
 
 (defmulti path-matches?
-  (fn [request-path route-path]
+  (fn [_ route-path]
     (type route-path)))
 
 (defmethod path-matches? String
@@ -14,21 +13,13 @@
   [request-path route-path]
   (not (nil? (re-matches route-path request-path))))
 
-(defn- route-matches? [{method :method path :path} route]
-  (and (= (first route) method)
-       (path-matches? path (second route))))
+(defn- find-route [{path :path} routes]
+  (first (filter #(path-matches? path (:path %)) routes)))
 
-(defn- find-route [request routes]
-  (first (filter (partial route-matches? request) routes)))
-
-(defn- has-route-for-path [{request-path :path} routes]
-  (some #(path-matches? request-path (second %)) routes))
-
-(defn choose-handler [request routes]
-  (let [matching-route (find-route request routes)]
-    (cond matching-route (last matching-route)
-          (has-route-for-path request routes) handler/method-not-allowed
-          :else handler/not-found)))
+(defn choose-handler [{:keys [method] :as request} routes]
+  (if-let [route (find-route request routes)]
+    (get-in route [:handlers method] handler/method-not-allowed)
+    handler/not-found))
 
 (defn route [request routes]
   (let [handler (choose-handler request routes)]

--- a/src/http_clj/router.clj
+++ b/src/http_clj/router.clj
@@ -2,10 +2,22 @@
   (:require [http-clj.response :as response]
             [http-clj.request-handler :as handler]))
 
+(defmulti path-matches?
+  (fn [request-path route-path]
+    (type route-path)))
+
+(defmethod path-matches? String
+  [request-path route-path]
+  (= request-path route-path))
+
+(defmethod path-matches? java.util.regex.Pattern
+  [request-path route-path]
+  (not (nil? (re-matches route-path request-path))))
+
 (defn- find-route [{method :method path :path} routes]
   (first
     (filter
-      #(and (= (first %1) method) (= (second %1) path))
+      #(and (= (first %1) method) (path-matches? path (second %1)))
       routes)))
 
 (defn route [request routes & {:keys [fallback]


### PR DESCRIPTION
With this change, if the router has one or more handlers for the requested path, but not for the specified method, the router will respond with a `405`. If the path is not specified at all, the router responds with a `404`.

I have reworked the router in a few ways to make this happen
1. The router is now a vector or maps, instead of a single map. A route looks like this now
2. The `:path` of the route can be either a string or a `regex.Pattern`
3. Now that patterns are supported, what use to be the "fallback" handler is now specified as a catch-all path. It is up to the application to add that catch-all.

Here is an example of an application's routes

``` clojure
[{:path #"^/foo$" :handlers {"GET" handlers/foo}}
 {:path "/log"    :handlers {"GET" handlers/log "POST" handlers/log}}
 {:path #"^/.*$"  :handlers {"GET" handlers/static}}]
```

![image](https://cloud.githubusercontent.com/assets/4121849/18056953/a929fe6e-6dd3-11e6-85c6-2f16a729512e.png)
