### PR TITLE
Head requests

### DIFF
--- a/spec/http_clj/request_handler_spec.clj
+++ b/spec/http_clj/request_handler_spec.clj
@@ -65,13 +65,13 @@
             resp (handler/head handler {})]
       (should= nil (:body resp))))
 
-    (it "it keeps the headers"
+    (it "keeps the headers"
       (let [handler #(response/create % "Body" :headers {"Host" "www.example.com"})
             resp (handler/head handler {})]
       (should= {"Host" "www.example.com"} (:headers resp))
       (should= 200 (:status resp)))))
 
-  (it "it keeps the status"
+  (it "keeps the status"
     (let [handler #(response/create % "Body" :status 201 :headers {"User-Agent" "test-agent"})
           resp (handler/head handler {})]
       (should= {"User-Agent" "test-agent"} (:headers resp)))))

--- a/spec/http_clj/request_handler_spec.clj
+++ b/spec/http_clj/request_handler_spec.clj
@@ -1,6 +1,7 @@
 (ns http-clj.request-handler-spec
   (:require [speclj.core :refer :all]
             [http-clj.request-handler :as handler]
+            [http-clj.response :as response]
             [clojure.java.io :as io]
             [hiccup.core :refer [html]])
   (:import java.io.File))
@@ -56,4 +57,21 @@
 
     (it "can accept a request and a file object"
       (let [{message :body} (handler/file {} (io/file @test-path))]
-        (should= (seq message) (seq (.getBytes @test-data)))))))
+        (should= (seq message) (seq (.getBytes @test-data))))))
+
+  (context "head"
+    (it "returns a resp with the body stripped out"
+      (let [handler #(response/create % "Body" :status 200)
+            resp (handler/head handler {})]
+      (should= nil (:body resp))))
+
+    (it "it keeps the headers"
+      (let [handler #(response/create % "Body" :headers {"Host" "www.example.com"})
+            resp (handler/head handler {})]
+      (should= {"Host" "www.example.com"} (:headers resp))
+      (should= 200 (:status resp)))))
+
+  (it "it keeps the status"
+    (let [handler #(response/create % "Body" :status 201 :headers {"User-Agent" "test-agent"})
+          resp (handler/head handler {})]
+      (should= {"User-Agent" "test-agent"} (:headers resp)))))

--- a/spec/http_clj/router_spec.clj
+++ b/spec/http_clj/router_spec.clj
@@ -94,25 +94,38 @@
   (context "GET"
     (with routes [{:path "/a" :handlers {}}])
     (it "adds the GET handler route to the route"
-      (let [routes (GET @routes "/b" :get-handler)]
-        (should= :get-handler (get-in (last routes) [:handlers "GET"]))))
+      (let [route (-> @routes
+                      (GET "/b" :get-handler)
+                      (find-route "/b"))]
+        (should= :get-handler (get-in route [:handlers "GET"]))))
 
     (it "appends the route to the end of the routes vector"
-      (should= "/b" (:path (last (GET @routes "/b" :get-handler)))))
+      (let [route (-> @routes
+                      (GET "/b" :get-handler)
+                      last)]
+      (should= "/b" (:path route))))
 
     (it "provides a default HEAD handler"
-      (let [routes (GET @routes "/b" :handler)]
-        (should-be clojure.test/function? (get-in (last routes) [:handlers "HEAD"]))))
+      (let [route (-> @routes
+                       (GET "/b" :handler)
+                       (find-route "/b"))]
+        (should-be clojure.test/function? (get-in route [:handlers "HEAD"]))))
 
     (it "an alternate HEAD handler can be specified"
-      (let [routes (GET @routes "/b" :get-handler :head-handler)]
-        (should= :head-handler (get-in (last routes) [:handlers "HEAD"]))))
+      (let [route (-> @routes
+                       (GET "/b" :get-handler :head-handler)
+                       (find-route "/b"))]
+        (should= :head-handler (get-in route [:handlers "HEAD"]))))
 
     (it "updates with a route if it is already defined"
-      (let [route (find-route (GET @routes "/a" :handler) "/a")]
+      (let [route (-> @routes
+                      (GET "/a" :handler)
+                      (find-route "/a"))]
         (should= :handler (get-in route [:handlers "GET"]))))
 
     (it "can update a route with a pattern"
-      (let [routes (GET @routes #"^/.*$" :first-handler)
-            routes (GET routes #"^/.*$" :second-handler)]
-        (should= :second-handler (get-in (find-route routes #"^/.*$") [:handlers "GET"]))))))
+      (let [route (-> @routes
+                       (GET #"^/.*$" :first-handler)
+                       (GET #"^/.*$" :second-handler)
+                       (find-route #"^/.*$")) ]
+        (should= :second-handler (get-in route [:handlers "GET"]))))))

--- a/spec/http_clj/router_spec.clj
+++ b/spec/http_clj/router_spec.clj
@@ -1,118 +1,118 @@
 (ns http-clj.router-spec
   (:require [speclj.core :refer :all]
-            [http-clj.router :as router]
+            [http-clj.router :refer :all]
             [http-clj.request-handler :as handler]))
 
-(defn fallback [request])
+(describe "router"
+  (context "route"
+    (with-stubs)
+    (with routes [{:path "/a" :handlers {"GET" (stub :handler-a)}}
+                  {:path "/b" :handlers {"POST" (stub :handler-b)}}
+                  {:path #"^/pattern/.*$" :handlers {"GET" (stub :handler-z)}}])
 
-(describe "a router"
-  (with-stubs)
-  (with routes [{:path "/a" :handlers {"GET" (stub :handler-a)}}
-                {:path "/b" :handlers {"POST" (stub :handler-b)}}
-                {:path #"^/pattern/.*$" :handlers {"GET" (stub :handler-z)}}])
+    (it "dispatches to handler-a"
+      (route {:method "GET" :path "/a"} @routes)
+      (should-not-have-invoked :handler-b)
+      (should-have-invoked :handler-a {:times 1}))
 
-  (it "dispatches to handler-a"
-    (router/route {:method "GET" :path "/a"} @routes)
-    (should-not-have-invoked :handler-b)
-    (should-have-invoked :handler-a {:times 1}))
+    (it "dispatches to handler-b"
+      (route {:method "POST" :path "/b"} @routes)
+      (should-not-have-invoked :handler-a)
+      (should-have-invoked :handler-b {:times 1}))
 
-  (it "dispatches to handler-b"
-    (router/route {:method "POST" :path "/b"} @routes)
-    (should-not-have-invoked :handler-a)
-    (should-have-invoked :handler-b {:times 1}))
+    (it "responds with not found if there is no matching route"
+      (let [{status :status body :body} (route
+                                          {:method "GET" :path "/"} @routes)]
+        (should= 404 status)))
 
-  (it "responds with not found if there is no matching route"
-    (let [{status :status body :body} (router/route
-                                        {:method "GET" :path "/"} @routes)]
-      (should= 404 status)))
+    (it "responds with method not allowed if the path matches but the method does not"
+      (let [{status :status body :body} (route
+                                          {:method "GET" :path "/b"} @routes)]
+        (should= 405 status)))
 
-  (it "responds with method not allowed if the path matches but the method does not"
-    (let [{status :status body :body} (router/route
-                                        {:method "GET" :path "/b"} @routes)]
-      (should= 405 status)))
+    (it "it will find the handler for a route defined as a pattern"
+      (let [request {:method "GET" :path "/pattern/handler-z"}
+            {status :status body :body} (route request @routes)]
+        (should-have-invoked :handler-z {:times 1}))))
 
-  (it "it will find the handler for a route defined as a pattern"
-    (let [request {:method "GET" :path "/pattern/handler-z"}
-          {status :status body :body} (router/route request @routes)]
-      (should-have-invoked :handler-z {:times 1}))))
+  (context "find-route"
+    (with routes [{:path "/a" :handlers {"GET" :handler-a}}
+                  {:path "/b" :handlers {"POST" :handler-b}}
+                  {:path #"^/pattern/.*$" :handlers {"GET" :handler-z}}])
 
-(describe "find-route"
-  (with routes [{:path "/a" :handlers {"GET" :handler-a}}
-                {:path "/b" :handlers {"POST" :handler-b}}
-                {:path #"^/pattern/.*$" :handlers {"GET" :handler-z}}])
+    (it "finds the route by path"
+      (should= {:path "/a" :handlers {"GET" :handler-a}}
+               (find-route @routes "/a")))
 
-  (it "finds the route by path"
-    (should= {:path "/a" :handlers {"GET" :handler-a}}
-             (router/find-route "/a" @routes)))
+    (it "is nil if there is no route for the path"
+      (should= nil (find-route @routes "/c")))
 
-  (it "is nil if there is no route for the path"
-    (should= nil (router/find-route "/c" @routes)))
+    (it "can find a route using a pattern"
+      (should= {"GET" :handler-z} (:handlers (find-route @routes #"^/pattern/.*$")))))
 
-  (it "can find a route using a pattern"
-    (should= {"GET" :handler-z} (:handlers (router/find-route #"^/pattern/.*$" @routes)))))
+  (context "update-route"
+    (with routes [{:path "/a" :handlers {"GET" :handler-a}}
+                  {:path #"^/path/.*$" :handlers {}}])
 
-(describe "update-route"
-  (with routes [{:path "/a" :handlers {"GET" :handler-a}}
-                {:path #"^/path/.*$" :handlers {}}])
+    (it "update the route if it exists"
+      (let [routes (update-route @routes {:path "/a" :handlers {"GET" :new-handler}})]
+        (should= {:path "/a" :handlers {"GET" :new-handler}} (find-route routes "/a"))))
 
-  (it "update the route if it exists"
-    (let [routes (router/update-route @routes {:path "/a" :handlers {"GET" :new-handler}})]
-    (should= {:path "/a" :handlers {"GET" :new-handler}} (router/find-route "/a" routes))))
+    (it "appends a new route if the path doesn't exist"
+      (let [routes (update-route @routes {:path "/b" :handlers {}})]
+        (should= {:path "/b" :handlers {}} (last routes))))
 
-  (it "appends a new route if the path doesn't exist"
-    (let [routes (router/update-route @routes {:path "/b" :handlers {}})]
-    (should= {:path "/b" :handlers {}} (last routes))))
+    (it "can update a route with a pattern path"
+      (let [routes (update-route @routes {:path #"^/path/.*$" :handlers {"GET" :handler}})]
+        (should= {"GET" :handler}  (:handlers (find-route routes #"^/path/.*$"))))))
 
-  (it "can update a route with a pattern path"
-    (let [routes (router/update-route @routes {:path #"^/path/.*$" :handlers {"GET" :handler}})]
-    (should= {"GET" :handler}  (:handlers (router/find-route #"^/path/.*$" routes))))))
+  (context "choose-handler"
+    (with routes [{:path "/a" :handlers {"GET" :handler-get-a "POST" :handler-post-a}}
+                  {:path "/b" :handlers {"HEAD" :handler-head-b "GET" :handler-get-b}}])
 
-(describe "choose-handler"
-  (with routes [{:path "/a" :handlers {"GET" :handler-get-a "POST" :handler-post-a}}
-                {:path "/b" :handlers {"HEAD" :handler-head-b "GET" :handler-get-b}}])
+    (it "chooses the get handler"
+      (let [request {:method "GET" :path "/a"}]
+        (should= :handler-get-a (choose-handler request @routes))))
 
-  (it "chooses the get handler"
-    (let [request {:method "GET" :path "/a"}]
-      (should= :handler-get-a (router/choose-handler request @routes))))
+    (it "chooses the post handler"
+      (let [request {:method "POST" :path "/a"}]
+        (should= :handler-post-a (choose-handler request @routes))))
 
-  (it "chooses the post handler"
-    (let [request {:method "POST" :path "/a"}]
-      (should= :handler-post-a (router/choose-handler request @routes))))
+    (it "chooses the head handler"
+      (let [request {:method "HEAD" :path "/b"}]
+        (should= :handler-head-b (choose-handler request @routes))))
 
-  (it "chooses the head handler"
-    (let [request {:method "HEAD" :path "/b"}]
-      (should= :handler-head-b (router/choose-handler request @routes))))
+    (it "returns method-not-allowed if the path exists but not the method"
+      (let [request {:method "DELETE" :path "/a"}]
+        (should= handler/method-not-allowed (choose-handler request @routes))))
 
-  (it "returns method-not-allowed if the path exists but not the method"
-    (let [request {:method "DELETE" :path "/a"}]
-    (should= handler/method-not-allowed (router/choose-handler request @routes))))
+    (it "returns not-found if the route does not exist"
+      (let [request {:method "DELETE" :path "/c"}]
+        (should= handler/not-found (choose-handler request @routes))))))
 
-  (it "returns not-found if the route does not exist"
-    (let [request {:method "DELETE" :path "/c"}]
-      (should= handler/not-found (router/choose-handler request @routes)))))
+(describe "route helpers"
+  (context "GET"
+    (with routes [{:path "/a" :handlers {}}])
+    (it "adds the GET handler route to the route"
+      (let [routes (GET @routes "/b" :get-handler)]
+        (should= :get-handler (get-in (last routes) [:handlers "GET"]))))
 
-(describe "GET"
-  (with routes [{:path "/a" :handlers {}}])
-  (it "it adds the GET handler route to the route"
-    (let [routes (router/GET @routes "/b" :get-handler)]
-      (should= :get-handler (get-in (last routes) [:handlers "GET"]))))
+    (it "appends the route to the end of the routes vector"
+      (should= "/b" (:path (last (GET @routes "/b" :get-handler)))))
 
-  (it "it appends the route to the end of the routes vector"
-    (should= "/b" (:path (last (router/GET @routes "/b" :get-handler)))))
+    (it "provides a default HEAD handler"
+      (let [routes (GET @routes "/b" :handler)]
+        (should-be clojure.test/function? (get-in (last routes) [:handlers "HEAD"]))))
 
-  (it "provides a default HEAD handler"
-    (let [routes (router/GET @routes "/b" :handler)]
-    (should-be clojure.test/function? (get-in (last routes) [:handlers "HEAD"]))))
+    (it "an alternate HEAD handler can be specified"
+      (let [routes (GET @routes "/b" :get-handler :head-handler)]
+        (should= :head-handler (get-in (last routes) [:handlers "HEAD"]))))
 
-  (it "an alternate HEAD handler can be specified"
-    (let [routes (router/GET @routes "/b" :get-handler :head-handler)]
-    (should= :head-handler (get-in (last routes) [:handlers "HEAD"]))))
+    (it "updates with a route if it is already defined"
+      (let [route (find-route (GET @routes "/a" :handler) "/a")]
+        (should= :handler (get-in route [:handlers "GET"]))))
 
-  (it "updates with a route if it is already defined"
-    (let [route (first (router/GET @routes "/a" :handler))]
-      (should= :handler (get-in route [:handlers "GET"]))))
-
-  (it "can update a route with a pattern"
-    (let [routes (router/GET @routes #"^/.*$" :first-handler)
-          routes (router/GET routes #"^/.*$" :second-handler)]
-      (should= :second-handler (get-in (router/find-route #"^/.*$" routes) [:handlers "GET"])))))
+    (it "can update a route with a pattern"
+      (let [routes (GET @routes #"^/.*$" :first-handler)
+            routes (GET routes #"^/.*$" :second-handler)]
+        (should= :second-handler (get-in (find-route routes #"^/.*$") [:handlers "GET"]))))))

--- a/spec/http_clj/router_spec.clj
+++ b/spec/http_clj/router_spec.clj
@@ -36,6 +36,37 @@
           {status :status body :body} (router/route request @routes)]
       (should-have-invoked :handler-z {:times 1}))))
 
+(describe "find-route"
+  (with routes [{:path "/a" :handlers {"GET" :handler-a}}
+                {:path "/b" :handlers {"POST" :handler-b}}
+                {:path #"^/pattern/.*$" :handlers {"GET" :handler-z}}])
+
+  (it "finds the route by path"
+    (should= {:path "/a" :handlers {"GET" :handler-a}}
+             (router/find-route "/a" @routes)))
+
+  (it "is nil if there is no route for the path"
+    (should= nil (router/find-route "/c" @routes)))
+
+  (it "can find a route using a pattern"
+    (should= {"GET" :handler-z} (:handlers (router/find-route #"^/pattern/.*$" @routes)))))
+
+(describe "update-route"
+  (with routes [{:path "/a" :handlers {"GET" :handler-a}}
+                {:path #"^/path/.*$" :handlers {}}])
+
+  (it "update the route if it exists"
+    (let [routes (router/update-route @routes {:path "/a" :handlers {"GET" :new-handler}})]
+    (should= {:path "/a" :handlers {"GET" :new-handler}} (router/find-route "/a" routes))))
+
+  (it "appends a new route if the path doesn't exist"
+    (let [routes (router/update-route @routes {:path "/b" :handlers {}})]
+    (should= {:path "/b" :handlers {}} (last routes))))
+
+  (it "can update a route with a pattern path"
+    (let [routes (router/update-route @routes {:path #"^/path/.*$" :handlers {"GET" :handler}})]
+    (should= {"GET" :handler}  (:handlers (router/find-route #"^/path/.*$" routes))))))
+
 (describe "choose-handler"
   (with routes [{:path "/a" :handlers {"GET" :handler-get-a "POST" :handler-post-a}}
                 {:path "/b" :handlers {"HEAD" :handler-head-b "GET" :handler-get-b}}])
@@ -59,3 +90,29 @@
   (it "returns not-found if the route does not exist"
     (let [request {:method "DELETE" :path "/c"}]
       (should= handler/not-found (router/choose-handler request @routes)))))
+
+(describe "GET"
+  (with routes [{:path "/a" :handlers {}}])
+  (it "it adds the GET handler route to the route"
+    (let [routes (router/GET @routes "/b" :get-handler)]
+      (should= :get-handler (get-in (last routes) [:handlers "GET"]))))
+
+  (it "it appends the route to the end of the routes vector"
+    (should= "/b" (:path (last (router/GET @routes "/b" :get-handler)))))
+
+  (it "provides a default HEAD handler"
+    (let [routes (router/GET @routes "/b" :handler)]
+    (should-be clojure.test/function? (get-in (last routes) [:handlers "HEAD"]))))
+
+  (it "an alternate HEAD handler can be specified"
+    (let [routes (router/GET @routes "/b" :get-handler :head-handler)]
+    (should= :head-handler (get-in (last routes) [:handlers "HEAD"]))))
+
+  (it "updates with a route if it is already defined"
+    (let [route (first (router/GET @routes "/a" :handler))]
+      (should= :handler (get-in route [:handlers "GET"]))))
+
+  (it "can update a route with a pattern"
+    (let [routes (router/GET @routes #"^/.*$" :first-handler)
+          routes (router/GET routes #"^/.*$" :second-handler)]
+      (should= :second-handler (get-in (router/find-route #"^/.*$" routes) [:handlers "GET"])))))

--- a/src/http_clj/app/cob_spec.clj
+++ b/src/http_clj/app/cob_spec.clj
@@ -1,5 +1,5 @@
 (ns http-clj.app.cob-spec
-  (:require [http-clj.router :refer [route]]
+  (:require [http-clj.router :refer [route GET]]
             [http-clj.server :refer [run]]
             [http-clj.app.cob-spec.handlers :as handlers]
             [http-clj.app.cob-spec.cli :as cli]
@@ -13,8 +13,9 @@
 (defn- cob-spec [request directory]
   (route
     request
-    [{:path "/log" :handlers {"GET" #(handlers/log % log)}}
-     {:path #"/.*" :handlers {"GET" #(handlers/static % directory)}}]))
+    (-> []
+       (GET "/log" #(handlers/log % log))
+       (GET #"^/.*$" #(handlers/static % directory)))))
 
 (defn app [directory]
   {:entrypoint #(cob-spec % directory)

--- a/src/http_clj/request_handler.clj
+++ b/src/http_clj/request_handler.clj
@@ -9,6 +9,11 @@
         html (template/directory files)]
   (response/create request html :headers {"Content-Type" "text/html"})))
 
+(defn head [handler request]
+  (-> request
+      handler
+      (assoc :body nil)))
+
 (defn not-found [request]
   (response/create request "Not Found" :status 404))
 

--- a/src/http_clj/router.clj
+++ b/src/http_clj/router.clj
@@ -1,26 +1,59 @@
 (ns http-clj.router
-  (:require [http-clj.request-handler :as handler]))
+  (:require [http-clj.request-handler :as handler])
+  (:import java.util.regex.Pattern))
 
 (defmulti path-matches?
-  (fn [_ route-path]
-    (type route-path)))
+  (fn [path route-path]
+    [(type path) (type route-path)]))
 
-(defmethod path-matches? String
+(defmethod path-matches? [String String]
   [request-path route-path]
   (= request-path route-path))
 
-(defmethod path-matches? java.util.regex.Pattern
+(defmethod path-matches? [String Pattern]
   [request-path route-path]
   (not (nil? (re-matches route-path request-path))))
 
-(defn- find-route [{path :path} routes]
+(defmethod path-matches? [Pattern Pattern]
+  [path route-path]
+  (= (.pattern path) (.pattern route-path)))
+
+(defmethod path-matches? [Pattern String]
+  [_ _]
+  false)
+
+(defn find-route [path routes]
   (first (filter #(path-matches? path (:path %)) routes)))
 
-(defn choose-handler [{:keys [method] :as request} routes]
-  (if-let [route (find-route request routes)]
+(defn lookup-route-id [routes path]
+  (first
+    (first
+      (filter #(path-matches? path (:path (second %)))
+              (map-indexed vector routes)))))
+
+(defn update-route [routes route]
+  (if-let [route-id (lookup-route-id routes (:path route))]
+    (update routes route-id merge route)
+    (conj routes route)))
+
+(defn choose-handler [{:keys [path method] :as request} routes]
+  (if-let [route (find-route path routes)]
     (get-in route [:handlers method] handler/method-not-allowed)
     handler/not-found))
 
 (defn route [request routes]
   (let [handler (choose-handler request routes)]
     (handler request)))
+
+(defn GET
+  ([routes path handler]
+   (GET routes
+        path
+        handler
+        (partial handler/head handler)))
+
+  ([routes path get-handler head-handler]
+   (update-route routes
+                 {:path path
+                  :handlers {"GET" get-handler
+                             "HEAD" head-handler}})))

--- a/src/http_clj/router.clj
+++ b/src/http_clj/router.clj
@@ -7,12 +7,12 @@
     [(type path) (type route-path)]))
 
 (defmethod path-matches? [String String]
-  [request-path route-path]
-  (= request-path route-path))
+  [path route-path]
+  (= path route-path))
 
 (defmethod path-matches? [String Pattern]
-  [request-path route-path]
-  (not (nil? (re-matches route-path request-path))))
+  [path route-path]
+  (not (nil? (re-matches route-path path))))
 
 (defmethod path-matches? [Pattern Pattern]
   [path route-path]
@@ -25,11 +25,20 @@
 (defn find-route [routes path]
   (first (filter #(path-matches? path (:path %)) routes)))
 
-(defn lookup-route-id [routes path]
-  (first
-    (first
-      (filter #(path-matches? path (:path (second %)))
-              (map-indexed vector routes)))))
+(defn- associate-route-ids [routes]
+  (map-indexed vector routes))
+
+(defn- filter-id-route-pairs-by-path [id-route-pairs path]
+  (filter #(path-matches? path (:path (second %))) id-route-pairs))
+
+(defn- extract-first-id [id-route-pairs]
+  (first (first id-route-pairs)))
+
+(defn- lookup-route-id [routes path]
+  (-> routes
+       associate-route-ids
+       (filter-id-route-pairs-by-path path)
+       extract-first-id))
 
 (defn update-route [routes route]
   (if-let [route-id (lookup-route-id routes (:path route))]

--- a/src/http_clj/router.clj
+++ b/src/http_clj/router.clj
@@ -20,6 +20,10 @@
 
 (defmethod path-matches? [Pattern String]
   [_ _]
+  ; A pattern should not match to a string in this direction
+  ; For instance, #"/.*" will match against the first path it
+  ; encounters instead of matching against a route with the
+  ; #"/.*" path.
   false)
 
 (defn find-route [routes path]

--- a/src/http_clj/router.clj
+++ b/src/http_clj/router.clj
@@ -22,7 +22,7 @@
   [_ _]
   false)
 
-(defn find-route [path routes]
+(defn find-route [routes path]
   (first (filter #(path-matches? path (:path %)) routes)))
 
 (defn lookup-route-id [routes path]
@@ -37,7 +37,7 @@
     (conj routes route)))
 
 (defn choose-handler [{:keys [path method] :as request} routes]
-  (if-let [route (find-route path routes)]
+  (if-let [route (find-route routes path)]
     (get-in route [:handlers method] handler/method-not-allowed)
     handler/not-found))
 


### PR DESCRIPTION
This introduces a the `head` handler, which wraps another handler and strips out the body of the response.

More interestingly, this adds a new route helper, `GET` which updates the route for the given path. If a route for the path does not exist, it will append it to the routes vector. This helper will also wrap the handler with the `head` function by default.

Example routes

``` clojure
(route
  request
  (-> []
    (GET "/a" my-handler)
    (GET #"^/.*$" my-handler my-option-handler)))
```

And now `SimpleHead` is passing 😸 
![image](https://cloud.githubusercontent.com/assets/4121849/18066719/33067a24-6dff-11e6-909a-97667b95727e.png)
