### PR TITLE
Post requests

### DIFF
--- a/spec/http_clj/app/cob_spec/handlers_spec.clj
+++ b/spec/http_clj/app/cob_spec/handlers_spec.clj
@@ -40,4 +40,3 @@
 
           (reset! cache "submitted=twice")
           (should= "submitted=twice" (:body (last-submission {} cache))))))))
-

--- a/spec/http_clj/app/cob_spec/handlers_spec.clj
+++ b/spec/http_clj/app/cob_spec/handlers_spec.clj
@@ -21,6 +21,23 @@
     (with request-log (io/writer @output))
 
     (it "displays the contents of the log"
-        (.write @request-log "message 1\n")
-        (.flush @request-log)
-        (should-contain "message 1\n" (:body (log {} @output))))))
+      (.write @request-log "message 1\n")
+      (.flush @request-log)
+      (should-contain "message 1\n" (:body (log {} @output)))))
+
+  (context "form"
+    (context "submit-form"
+    (it "updates the form"
+      (let [cache (atom "")]
+        (should= 200 (:status (submit-form {:body (.getBytes "submitted=true")} cache)))
+        (should= "submitted=true" @cache))))
+
+    (context "last-submission"
+      (it "displays the content of the last submission"
+        (let [cache (atom "submitted=true")]
+          (should= 200 (:status (last-submission {} cache)))
+          (should= "submitted=true" (:body (last-submission {} cache)))
+
+          (reset! cache "submitted=twice")
+          (should= "submitted=twice" (:body (last-submission {} cache))))))))
+

--- a/spec/http_clj/app/cob_spec_spec.clj
+++ b/spec/http_clj/app/cob_spec_spec.clj
@@ -27,6 +27,10 @@
 (defn GET [path]
   (client/get (str root path) {:throw-exceptions false}))
 
+(defn POST [path data]
+  (client/post (str root path) {:form-params data
+                                :throw-exceptions false}))
+
 (def thread (atom nil))
 
 (describe "cob-spec"
@@ -38,8 +42,15 @@
       (should-contain "file.txt" body)
       (should-contain "image.gif" body)))
 
-    (it "has /image.gif"
-      (should= 200 (:status (GET "/image.gif"))))
+  (it "has /image.gif"
+    (should= 200 (:status (GET "/image.gif"))))
 
-    (it "has a viewable log"
-      (should-contain "GET /log HTTP/1.1" (:body (GET "/log")))))
+  (it "has a viewable log"
+    (should-contain "GET /log HTTP/1.1" (:body (GET "/log"))))
+
+  (it "data can be posted to /form"
+    (let [{status :status} (POST "/form" {:form-data true})]
+      (should= 200 status))
+    (should-contain "form-data=true" (:body (GET "/form")))
+    (POST "/form" {:new-form-data true})
+    (should-contain "new-form-data=true" (:body (GET "/form")))))

--- a/spec/http_clj/connection_spec.clj
+++ b/spec/http_clj/connection_spec.clj
@@ -11,9 +11,9 @@
 (describe "a connection"
   (with conn (connection/create (mock/socket "line 1\nline 2" output)))
 
-  (it "can be have lines read from it"
-    (should= "line 1" (connection/readline @conn))
-    (should= "line 2" (connection/readline @conn)))
+  (it "reads one character"
+    (should= (int \l) (connection/read-char @conn))
+    (should= (int \i) (connection/read-char @conn)))
 
   (it "can be read into a buffer"
     (let [buffer-length (alength (.getBytes "line 1\nline 2"))

--- a/spec/http_clj/connection_spec.clj
+++ b/spec/http_clj/connection_spec.clj
@@ -11,9 +11,9 @@
 (describe "a connection"
   (with conn (connection/create (mock/socket "line 1\nline 2" output)))
 
-  (it "reads one character"
-    (should= (int \l) (connection/read-char @conn))
-    (should= (int \i) (connection/read-char @conn)))
+  (it "reads one byte"
+    (should= (byte \l) (connection/read-byte @conn))
+    (should= (byte \i) (connection/read-byte @conn)))
 
   (it "reads the input as a byte array"
     (let [length (alength (.getBytes "line 1\nline 2"))]

--- a/spec/http_clj/connection_spec.clj
+++ b/spec/http_clj/connection_spec.clj
@@ -17,7 +17,7 @@
 
   (it "can be read into a buffer"
     (let [buffer-length (alength (.getBytes "line 1\nline 2"))
-          buffer (connection/read @conn (byte-array buffer-length))]
+          buffer (connection/read-bytes @conn (byte-array buffer-length))]
       (should= "line 1\nline 2" (String. buffer))))
 
   (it "will yield a connection when written to"

--- a/spec/http_clj/connection_spec.clj
+++ b/spec/http_clj/connection_spec.clj
@@ -15,10 +15,9 @@
     (should= (int \l) (connection/read-char @conn))
     (should= (int \i) (connection/read-char @conn)))
 
-  (it "can be read into a buffer"
-    (let [buffer-length (alength (.getBytes "line 1\nline 2"))
-          buffer (connection/read-bytes @conn (byte-array buffer-length))]
-      (should= "line 1\nline 2" (String. buffer))))
+  (it "reads the input as a byte array"
+    (let [length (alength (.getBytes "line 1\nline 2"))]
+      (should= "line 1\nline 2" (String. (connection/read-bytes @conn length)))))
 
   (it "will yield a connection when written to"
     (should= @conn (connection/write @conn (.getBytes ""))))

--- a/spec/http_clj/request/parser_spec.clj
+++ b/spec/http_clj/request/parser_spec.clj
@@ -7,9 +7,9 @@
 
 (describe "request.parser"
   (with get-request
-   {:conn  (mock/connection
-      (GET "/file1"
-           {"Host" "www.example.com" "User-Agent" "Test-request"}))})
+    {:conn  (mock/connection
+              (GET "/file1"
+                   {"Host" "www.example.com" "User-Agent" "Test-request"}))})
 
   (with post-request
     {:conn (mock/connection
@@ -17,22 +17,33 @@
                    {"Host" "www.example.us" "User-Agent" "Test-request"}
                    "var=data"))})
 
-     (context "parse-request-line"
-       (it "parses the method"
-         (should= "GET" (:method (parser/request-line @get-request)))
-         (should= "POST" (:method (parser/request-line @post-request))))
+  (context "readline"
+    (it "reads line delimited by newline characters"
+      (let [conn (mock/connection "one\ntwo")]
+        (should= "one" (parser/readline conn))
+        (should= "two" (parser/readline conn))))
 
-       (it "parses the path"
-         (should= "/file1" (:path (parser/request-line @get-request)))
-         (should= "/file2" (:path (parser/request-line @post-request))))
+    (it "reads line delimited by carriage returns"
+      (let [conn (mock/connection "one\r\ntwo")]
+        (should= "one" (parser/readline conn))
+        (should= "two" (parser/readline conn)))))
 
-       (it "parses the version"
-         (should= "HTTP/1.1" (:version (parser/request-line @get-request)))
-         (should= "HTTP/1.1" (:version (parser/request-line @post-request)))))
+  (context "parse-request-line"
+    (it "parses the method"
+      (should= "GET" (:method (parser/request-line @get-request)))
+      (should= "POST" (:method (parser/request-line @post-request))))
 
-     (context "parse-headers"
-       (before (parser/request-line @get-request))
+    (it "parses the path"
+      (should= "/file1" (:path (parser/request-line @get-request)))
+      (should= "/file2" (:path (parser/request-line @post-request))))
 
-       (it "parses the headers"
-         (should= {"Host" "www.example.com" "User-Agent" "Test-request"}
-                  (parser/headers @get-request)))))
+    (it "parses the version"
+      (should= "HTTP/1.1" (:version (parser/request-line @get-request)))
+      (should= "HTTP/1.1" (:version (parser/request-line @post-request)))))
+
+  (context "parse-headers"
+    (before (parser/request-line @get-request))
+
+    (it "parses the headers"
+      (should= {"Host" "www.example.com" "User-Agent" "Test-request"}
+               (parser/headers @get-request)))))

--- a/spec/http_clj/request/parser_spec.clj
+++ b/spec/http_clj/request/parser_spec.clj
@@ -14,7 +14,9 @@
   (with post-request
     {:conn (mock/connection
              (POST "/file2"
-                   {"Host" "www.example.us" "User-Agent" "Test-request"}
+                   {"Host" "www.example.us"
+                    "User-Agent" "Test-request"
+                    "Content-Length" 8}
                    "var=data"))})
 
   (context "readline"
@@ -46,4 +48,16 @@
 
     (it "parses the headers"
       (should= {"Host" "www.example.com" "User-Agent" "Test-request"}
-               (parser/headers @get-request)))))
+               (parser/headers @get-request))))
+
+  (context "read-body"
+    (it "is nil if the there is not body to read"
+      (let [request (-> @get-request
+                        (merge  (parser/request-line @get-request))
+                        (assoc :headers (parser/headers @get-request)))]
+      (should= nil (parser/read-body request))))
+    (it "returns the body if present"
+      (let [request (-> @post-request
+                        (merge  (parser/request-line @post-request))
+                        (assoc :headers (parser/headers@post-request)))]
+      (should= "var=data" (String. (parser/read-body request)))))))

--- a/spec/http_clj/request/parser_spec.clj
+++ b/spec/http_clj/request/parser_spec.clj
@@ -55,9 +55,9 @@
       (let [request (-> @get-request
                         (merge  (parser/request-line @get-request))
                         (assoc :headers (parser/headers @get-request)))]
-      (should= nil (parser/read-body request))))
+        (should= nil (parser/read-body request))))
     (it "returns the body if present"
       (let [request (-> @post-request
                         (merge  (parser/request-line @post-request))
                         (assoc :headers (parser/headers@post-request)))]
-      (should= "var=data" (String. (parser/read-body request)))))))
+        (should= "var=data" (String. (parser/read-body request)))))))

--- a/spec/http_clj/request_spec.clj
+++ b/spec/http_clj/request_spec.clj
@@ -13,7 +13,9 @@
   (with post-conn
     (mock/connection
       (POST "/file2"
-            {"Host" "www.example.us" "User-Agent" "Test-request"}
+            {"Host" "www.example.us"
+             "User-Agent" "Test-request"
+             "Content-Length" 8}
             "var=data")))
 
   (context "when created"
@@ -35,6 +37,9 @@
     (it "has headers"
       (should= "www.example.com"
                (get-in (request/create @get-conn) [:headers "Host"]))
-
       (should= "www.example.us"
-               (get-in (request/create @post-conn) [:headers "Host"])))))
+               (get-in (request/create @post-conn) [:headers "Host"])))
+
+    (it "has a body"
+      (should= nil (:body (request/create @get-conn)))
+      (should= "var=data" (String. (:body (request/create @post-conn)))))))

--- a/spec/http_clj/router/route_helpers_spec.clj
+++ b/spec/http_clj/router/route_helpers_spec.clj
@@ -4,7 +4,7 @@
 
 (describe "router.route-helpers"
   (context "find-route"
-    (with routes [{:path "/a" :handlers {"GET" :handler-a}}
+    (with routes [{:path "/a" :handlers {"GET" :handler-a }}
                   {:path "/b" :handlers {"POST" :handler-b}}
                   {:path #"^/pattern/.*$" :handlers {"GET" :handler-z}}])
 
@@ -19,12 +19,13 @@
       (should= {"GET" :handler-z} (:handlers (find-route @routes #"^/pattern/.*$")))))
 
   (context "update-route"
-    (with routes [{:path "/a" :handlers {"GET" :handler-a}}
+    (with routes [{:path "/a" :handlers {"GET" :get-handler "POST" :post-handler}}
                   {:path #"^/path/.*$" :handlers {}}])
 
     (it "update the route if it exists"
       (let [routes (update-route @routes {:path "/a" :handlers {"GET" :new-handler}})]
-        (should= {:path "/a" :handlers {"GET" :new-handler}} (find-route routes "/a"))))
+        (should= {:path "/a" :handlers {"GET" :new-handler "POST" :post-handler}}
+                 (find-route routes "/a"))))
 
     (it "appends a new route if the path doesn't exist"
       (let [routes (update-route @routes {:path "/b" :handlers {}})]
@@ -33,4 +34,3 @@
     (it "can update a route with a pattern path"
       (let [routes (update-route @routes {:path #"^/path/.*$" :handlers {"GET" :handler}})]
         (should= {"GET" :handler}  (:handlers (find-route routes #"^/path/.*$")))))))
-

--- a/spec/http_clj/router/route_helpers_spec.clj
+++ b/spec/http_clj/router/route_helpers_spec.clj
@@ -1,0 +1,36 @@
+(ns http-clj.router.route-helpers-spec
+  (:require [speclj.core :refer :all]
+            [http-clj.router.route-helpers :refer :all]))
+
+(describe "router.route-helpers"
+  (context "find-route"
+    (with routes [{:path "/a" :handlers {"GET" :handler-a}}
+                  {:path "/b" :handlers {"POST" :handler-b}}
+                  {:path #"^/pattern/.*$" :handlers {"GET" :handler-z}}])
+
+    (it "finds the route by path"
+      (should= {:path "/a" :handlers {"GET" :handler-a}}
+               (find-route @routes "/a")))
+
+    (it "is nil if there is no route for the path"
+      (should= nil (find-route @routes "/c")))
+
+    (it "can find a route using a pattern"
+      (should= {"GET" :handler-z} (:handlers (find-route @routes #"^/pattern/.*$")))))
+
+  (context "update-route"
+    (with routes [{:path "/a" :handlers {"GET" :handler-a}}
+                  {:path #"^/path/.*$" :handlers {}}])
+
+    (it "update the route if it exists"
+      (let [routes (update-route @routes {:path "/a" :handlers {"GET" :new-handler}})]
+        (should= {:path "/a" :handlers {"GET" :new-handler}} (find-route routes "/a"))))
+
+    (it "appends a new route if the path doesn't exist"
+      (let [routes (update-route @routes {:path "/b" :handlers {}})]
+        (should= {:path "/b" :handlers {}} (last routes))))
+
+    (it "can update a route with a pattern path"
+      (let [routes (update-route @routes {:path #"^/path/.*$" :handlers {"GET" :handler}})]
+        (should= {"GET" :handler}  (:handlers (find-route routes #"^/path/.*$")))))))
+

--- a/spec/http_clj/router_spec.clj
+++ b/spec/http_clj/router_spec.clj
@@ -1,6 +1,7 @@
 (ns http-clj.router-spec
   (:require [speclj.core :refer :all]
             [http-clj.router :refer :all]
+            [http-clj.router.route-helpers :refer [find-route]]
             [http-clj.request-handler :as handler]))
 
 (describe "router"
@@ -35,37 +36,6 @@
             {status :status body :body} (route request @routes)]
         (should-have-invoked :handler-z {:times 1}))))
 
-  (context "find-route"
-    (with routes [{:path "/a" :handlers {"GET" :handler-a}}
-                  {:path "/b" :handlers {"POST" :handler-b}}
-                  {:path #"^/pattern/.*$" :handlers {"GET" :handler-z}}])
-
-    (it "finds the route by path"
-      (should= {:path "/a" :handlers {"GET" :handler-a}}
-               (find-route @routes "/a")))
-
-    (it "is nil if there is no route for the path"
-      (should= nil (find-route @routes "/c")))
-
-    (it "can find a route using a pattern"
-      (should= {"GET" :handler-z} (:handlers (find-route @routes #"^/pattern/.*$")))))
-
-  (context "update-route"
-    (with routes [{:path "/a" :handlers {"GET" :handler-a}}
-                  {:path #"^/path/.*$" :handlers {}}])
-
-    (it "update the route if it exists"
-      (let [routes (update-route @routes {:path "/a" :handlers {"GET" :new-handler}})]
-        (should= {:path "/a" :handlers {"GET" :new-handler}} (find-route routes "/a"))))
-
-    (it "appends a new route if the path doesn't exist"
-      (let [routes (update-route @routes {:path "/b" :handlers {}})]
-        (should= {:path "/b" :handlers {}} (last routes))))
-
-    (it "can update a route with a pattern path"
-      (let [routes (update-route @routes {:path #"^/path/.*$" :handlers {"GET" :handler}})]
-        (should= {"GET" :handler}  (:handlers (find-route routes #"^/path/.*$"))))))
-
   (context "choose-handler"
     (with routes [{:path "/a" :handlers {"GET" :handler-get-a "POST" :handler-post-a}}
                   {:path "/b" :handlers {"HEAD" :handler-head-b "GET" :handler-get-b}}])
@@ -88,44 +58,44 @@
 
     (it "returns not-found if the route does not exist"
       (let [request {:method "DELETE" :path "/c"}]
-        (should= handler/not-found (choose-handler request @routes))))))
+        (should= handler/not-found (choose-handler request @routes)))))
 
-(describe "route helpers"
-  (context "GET"
-    (with routes [{:path "/a" :handlers {}}])
-    (it "adds the GET handler route to the route"
-      (let [route (-> @routes
-                      (GET "/b" :get-handler)
-                      (find-route "/b"))]
-        (should= :get-handler (get-in route [:handlers "GET"]))))
+  (context "routes functions"
+    (context "GET"
+      (with routes [{:path "/a" :handlers {}}])
+      (it "adds the GET handler route to the route"
+        (let [route (-> @routes
+                        (GET "/b" :get-handler)
+                        (find-route "/b"))]
+          (should= :get-handler (get-in route [:handlers "GET"]))))
 
-    (it "appends the route to the end of the routes vector"
-      (let [route (-> @routes
-                      (GET "/b" :get-handler)
-                      last)]
-      (should= "/b" (:path route))))
+      (it "appends the route to the end of the routes vector"
+        (let [route (-> @routes
+                        (GET "/b" :get-handler)
+                        last)]
+          (should= "/b" (:path route))))
 
-    (it "provides a default HEAD handler"
-      (let [route (-> @routes
-                       (GET "/b" :handler)
-                       (find-route "/b"))]
-        (should-be clojure.test/function? (get-in route [:handlers "HEAD"]))))
+      (it "provides a default HEAD handler"
+        (let [route (-> @routes
+                        (GET "/b" :handler)
+                        (find-route "/b"))]
+          (should-be clojure.test/function? (get-in route [:handlers "HEAD"]))))
 
-    (it "an alternate HEAD handler can be specified"
-      (let [route (-> @routes
-                       (GET "/b" :get-handler :head-handler)
-                       (find-route "/b"))]
-        (should= :head-handler (get-in route [:handlers "HEAD"]))))
+      (it "an alternate HEAD handler can be specified"
+        (let [route (-> @routes
+                        (GET "/b" :get-handler :head-handler)
+                        (find-route "/b"))]
+          (should= :head-handler (get-in route [:handlers "HEAD"]))))
 
-    (it "updates with a route if it is already defined"
-      (let [route (-> @routes
-                      (GET "/a" :handler)
-                      (find-route "/a"))]
-        (should= :handler (get-in route [:handlers "GET"]))))
+      (it "updates with a route if it is already defined"
+        (let [route (-> @routes
+                        (GET "/a" :handler)
+                        (find-route "/a"))]
+          (should= :handler (get-in route [:handlers "GET"]))))
 
-    (it "can update a route with a pattern"
-      (let [route (-> @routes
-                       (GET #"^/.*$" :first-handler)
-                       (GET #"^/.*$" :second-handler)
-                       (find-route #"^/.*$")) ]
-        (should= :second-handler (get-in route [:handlers "GET"]))))))
+      (it "can update a route with a pattern"
+        (let [route (-> @routes
+                        (GET #"^/.*$" :first-handler)
+                        (GET #"^/.*$" :second-handler)
+                        (find-route #"^/.*$")) ]
+          (should= :second-handler (get-in route [:handlers "GET"])))))))

--- a/spec/http_clj/router_spec.clj
+++ b/spec/http_clj/router_spec.clj
@@ -98,4 +98,15 @@
                         (GET #"^/.*$" :first-handler)
                         (GET #"^/.*$" :second-handler)
                         (find-route #"^/.*$")) ]
-          (should= :second-handler (get-in route [:handlers "GET"])))))))
+          (should= :second-handler (get-in route [:handlers "GET"]))))))
+
+  (context "POST"
+    (with routes [{:path "/a" :handlers {}}])
+
+    (it "appends a route if the path isn't defined"
+      (let [routes (POST @routes "/b" :handler)]
+        (should= {:path "/b" :handlers {"POST" :handler}} (last routes))))
+
+    (it "updates the route if the path is defined"
+      (let [routes (POST @routes "/a" :handler)]
+        (should= {:path "/a" :handlers {"POST" :handler}} (first routes))))))

--- a/spec/http_clj/server_spec.clj
+++ b/spec/http_clj/server_spec.clj
@@ -37,7 +37,7 @@
   (log [this level contents]))
 
 (defn test-app [request]
-  (when (not (:open (:conn request)))
+  (when (.isClosed (:socket (:conn request)))
     (should-fail "The connection should be open"))
   (response/create request "App was called"))
 
@@ -50,8 +50,8 @@
                    (s/listen @server @application)))
 
   (it "closes the connection"
-    (let [{open :open} (s/listen @server @application)]
-      (should= false open))))
+    (let [{socket :socket} (s/listen @server @application)]
+      (should= nil socket))))
 
 (defn interrupting-app [request]
   (loop [count 3]

--- a/spec/http_clj/spec_helper/mock.clj
+++ b/spec/http_clj/spec_helper/mock.clj
@@ -6,7 +6,9 @@
   (:import java.io.ByteArrayInputStream
            java.io.ByteArrayOutputStream))
 
-(defn socket [input output]
+(defn socket
+  ([input] (socket input nil))
+  ([input output]
   (let [connected? (atom true)
         input-stream (ByteArrayInputStream. (.getBytes input))]
     (proxy [java.net.Socket] []
@@ -20,7 +22,7 @@
         output)
 
       (getInputStream []
-        input-stream))))
+        input-stream)))))
 
 (defn socket-server [& args]
   (let [closed? (atom false)]
@@ -34,27 +36,11 @@
       (isClosed []
         @closed?))))
 
-(defrecord MockConnection [open input-stream]
-  connection/Connection
-  (write [conn text]
-    (assoc conn :written-to-connection (String. text)))
-
-  (read-byte [conn]
-    (.read input-stream))
-
-  (read-bytes [conn length]
-    (let [buffer (byte-array length)]
-      (.read input-stream buffer)
-      buffer))
-
-  (close [conn]
-    (assoc conn :open false)))
-
 (defn connection
   ([]
    (connection ""))
   ([input]
-   (MockConnection. true (ByteArrayInputStream. (.getBytes input)))))
+   (connection/create (socket input (ByteArrayOutputStream.)))))
 
 (defrecord MockServer [started stopped]
   component/Lifecycle

--- a/spec/http_clj/spec_helper/mock.clj
+++ b/spec/http_clj/spec_helper/mock.clj
@@ -35,13 +35,16 @@
       (isClosed []
         @closed?))))
 
-(defrecord MockConnection [open input]
+(defrecord MockConnection [open input-stream reader]
   connection/Connection
   (readline [conn]
-    (.readLine input))
+    (.readLine reader))
 
   (write [conn text]
     (assoc conn :written-to-connection (String. text)))
+
+  (read [conn buffer]
+    (.read input-stream buffer))
 
   (close [conn]
     (assoc conn :open false)))
@@ -50,7 +53,9 @@
   ([]
    (connection ""))
   ([input]
-   (MockConnection. true (io/reader (.getBytes input)))))
+   (let [input-stream (ByteArrayInputStream. (.getBytes input))
+         reader (io/reader input-stream)]
+   (MockConnection. true input-stream reader))))
 
 (defrecord MockServer [started stopped]
   component/Lifecycle

--- a/spec/http_clj/spec_helper/mock.clj
+++ b/spec/http_clj/spec_helper/mock.clj
@@ -37,11 +37,11 @@
 
 (defrecord MockConnection [open input-stream reader]
   connection/Connection
-  (readline [conn]
-    (.readLine reader))
-
   (write [conn text]
     (assoc conn :written-to-connection (String. text)))
+
+  (read-char [conn]
+    (.read reader))
 
   (read [conn buffer]
     (.read input-stream buffer))

--- a/spec/http_clj/spec_helper/mock.clj
+++ b/spec/http_clj/spec_helper/mock.clj
@@ -43,8 +43,10 @@
   (read-char [conn]
     (.read reader))
 
-  (read-bytes [conn buffer]
-    (.read input-stream buffer))
+  (read-bytes [conn length]
+    (let [buffer (byte-array length)]
+      (.read input-stream buffer)
+      buffer))
 
   (close [conn]
     (assoc conn :open false)))
@@ -53,9 +55,8 @@
   ([]
    (connection ""))
   ([input]
-   (let [input-stream (ByteArrayInputStream. (.getBytes input))
-         reader (io/reader input-stream)]
-   (MockConnection. true input-stream reader))))
+   (let [input-stream (ByteArrayInputStream. (.getBytes input))]
+     (MockConnection. true input-stream input-stream))))
 
 (defrecord MockServer [started stopped]
   component/Lifecycle

--- a/spec/http_clj/spec_helper/mock.clj
+++ b/spec/http_clj/spec_helper/mock.clj
@@ -43,7 +43,7 @@
   (read-char [conn]
     (.read reader))
 
-  (read [conn buffer]
+  (read-bytes [conn buffer]
     (.read input-stream buffer))
 
   (close [conn]

--- a/src/http_clj/app/cob_spec.clj
+++ b/src/http_clj/app/cob_spec.clj
@@ -1,5 +1,5 @@
 (ns http-clj.app.cob-spec
-  (:require [http-clj.router :refer [route GET]]
+  (:require [http-clj.router :refer [route GET POST]]
             [http-clj.server :refer [run]]
             [http-clj.app.cob-spec.handlers :as handlers]
             [http-clj.app.cob-spec.cli :as cli]
@@ -9,12 +9,15 @@
   (:import java.io.ByteArrayOutputStream))
 
 (def log (ByteArrayOutputStream.))
+(def form-cache (atom ""))
 
 (defn- cob-spec [request directory]
   (route
     request
     (-> []
        (GET "/log" #(handlers/log % log))
+       (POST "/form" #(handlers/submit-form % form-cache))
+       (GET "/form" #(handlers/last-submission % form-cache))
        (GET #"^/.*$" #(handlers/static % directory)))))
 
 (defn app [directory]

--- a/src/http_clj/app/cob_spec/handlers.clj
+++ b/src/http_clj/app/cob_spec/handlers.clj
@@ -11,3 +11,10 @@
 
 (defn log [request log]
   (response/create request (.toString log)))
+
+(defn submit-form [request cache]
+  (reset! cache (String. (:body request)))
+  (response/create request ""))
+
+(defn last-submission [request cache]
+  (response/create request @cache))

--- a/src/http_clj/connection.clj
+++ b/src/http_clj/connection.clj
@@ -5,14 +5,14 @@
 
 (defprotocol Connection
   (read-bytes [conn buffer])
-  (read-char [conn])
+  (read-byte [conn])
   (write [conn output])
   (close [conn]))
 
 (defrecord SocketConnection [socket reader writer]
   Connection
-  (read-char [conn]
-    (.read reader))
+  (read-byte [conn]
+    (.read (.getInputStream socket)))
 
   (read-bytes [conn length]
     (let [buffer (byte-array length)]
@@ -32,5 +32,5 @@
   ([host port] (create (Socket. host port)))
   ([socket]
    (map->SocketConnection {:socket socket
-                           :reader (InputStreamReader. (.getInputStream socket))
+                           :reader (.getInputStream socket)
                            :writer (.getOutputStream socket)})))

--- a/src/http_clj/connection.clj
+++ b/src/http_clj/connection.clj
@@ -14,9 +14,10 @@
   (read-char [conn]
     (.read reader))
 
-  (read-bytes [conn buffer]
-    (.read (.getInputStream socket) buffer)
-    buffer)
+  (read-bytes [conn length]
+    (let [buffer (byte-array length)]
+      (.read (.getInputStream socket) buffer)
+      buffer))
 
   (write [conn output]
     (.write writer output)

--- a/src/http_clj/connection.clj
+++ b/src/http_clj/connection.clj
@@ -4,7 +4,7 @@
            java.io.InputStreamReader))
 
 (defprotocol Connection
-  (read [conn buffer])
+  (read-bytes [conn buffer])
   (read-char [conn])
   (write [conn output])
   (close [conn]))
@@ -14,7 +14,7 @@
   (read-char [conn]
     (.read reader))
 
-  (read [conn buffer]
+  (read-bytes [conn buffer]
     (.read (.getInputStream socket) buffer)
     buffer)
 

--- a/src/http_clj/connection.clj
+++ b/src/http_clj/connection.clj
@@ -1,18 +1,18 @@
 (ns http-clj.connection
   (:require [clojure.java.io :as io])
-  (:import java.net.Socket))
+  (:import java.net.Socket
+           java.io.InputStreamReader))
 
 (defprotocol Connection
-  (readline [conn])
   (read [conn buffer])
+  (read-char [conn])
   (write [conn output])
   (close [conn]))
 
 (defrecord SocketConnection [socket reader writer]
   Connection
-
-  (readline [conn]
-    (.readLine reader))
+  (read-char [conn]
+    (.read reader))
 
   (read [conn buffer]
     (.read (.getInputStream socket) buffer)
@@ -31,5 +31,5 @@
   ([host port] (create (Socket. host port)))
   ([socket]
    (map->SocketConnection {:socket socket
-                           :reader (io/reader socket)
+                           :reader (InputStreamReader. (.getInputStream socket))
                            :writer (.getOutputStream socket)})))

--- a/src/http_clj/connection.clj
+++ b/src/http_clj/connection.clj
@@ -9,19 +9,21 @@
   (write [conn output])
   (close [conn]))
 
-(defrecord SocketConnection [socket reader writer]
+(defrecord SocketConnection [socket]
   Connection
   (read-byte [conn]
     (.read (.getInputStream socket)))
 
   (read-bytes [conn length]
     (let [buffer (byte-array length)]
-      (.read (.getInputStream socket) buffer)
+      (doto (.getInputStream socket)
+        (.read buffer))
       buffer))
 
   (write [conn output]
-    (.write writer output)
-    (.flush writer)
+    (doto (.getOutputStream socket)
+      (.write output)
+      (.flush))
     conn)
 
   (close [conn]
@@ -31,6 +33,4 @@
 (defn create
   ([host port] (create (Socket. host port)))
   ([socket]
-   (map->SocketConnection {:socket socket
-                           :reader (.getInputStream socket)
-                           :writer (.getOutputStream socket)})))
+   (map->SocketConnection {:socket socket})))

--- a/src/http_clj/connection.clj
+++ b/src/http_clj/connection.clj
@@ -4,6 +4,7 @@
 
 (defprotocol Connection
   (readline [conn])
+  (read [conn buffer])
   (write [conn output])
   (close [conn]))
 
@@ -12,6 +13,10 @@
 
   (readline [conn]
     (.readLine reader))
+
+  (read [conn buffer]
+    (.read (.getInputStream socket) buffer)
+    buffer)
 
   (write [conn output]
     (.write writer output)

--- a/src/http_clj/request.clj
+++ b/src/http_clj/request.clj
@@ -10,7 +10,11 @@
 (defn- attach-headers [request]
   (assoc request :headers (parser/headers request)))
 
+(defn- attach-body [request]
+  (assoc request :body (parser/read-body request)))
+
 (defn create [conn]
    (-> {:conn conn}
        attach-request-line
-       attach-headers))
+       attach-headers
+       attach-body))

--- a/src/http_clj/request/parser.clj
+++ b/src/http_clj/request/parser.clj
@@ -4,7 +4,7 @@
 
 (defn readline [conn]
     (loop [line []]
-      (let [character (connection/read-char conn)]
+      (let [character (connection/read-byte conn)]
         (if (some #(= character %) (map int [\newline -1]))
           (String. (byte-array (filter #(not= (int \return) %) line)))
           (recur (conj line character))))))

--- a/src/http_clj/request/parser.clj
+++ b/src/http_clj/request/parser.clj
@@ -2,9 +2,16 @@
   (:require [http-clj.connection :as connection]
             [clojure.string :as string]))
 
+(defn readline [conn]
+    (loop [line []]
+      (let [character (connection/read-char conn)]
+        (if (some #(= character %) (map int [\newline -1]))
+          (String. (byte-array (filter #(not= (int \return) %) line)))
+          (recur (conj line character))))))
+
 (defn- split-request-line [conn]
   (-> conn
-      (connection/readline)
+      (readline)
       (string/split #" ")))
 
 (defn request-line [request]
@@ -19,7 +26,7 @@
 
 (defn headers [request]
   (loop [conn (:conn request) headers {}]
-    (let [header (connection/readline conn)]
+    (let [header (readline conn)]
       (if (empty? header)
         headers
         (recur conn (merge headers (parse-header header)))))))

--- a/src/http_clj/request/parser.clj
+++ b/src/http_clj/request/parser.clj
@@ -30,3 +30,7 @@
       (if (empty? header)
         headers
         (recur conn (merge headers (parse-header header)))))))
+
+(defn read-body [{:keys [headers conn]}]
+  (if-let [content-length (get headers "Content-Length")]
+    (connection/read-bytes conn (Integer/parseInt content-length))))

--- a/src/http_clj/router.clj
+++ b/src/http_clj/router.clj
@@ -19,7 +19,14 @@
         (partial handler/head handler)))
 
   ([routes path get-handler head-handler]
-   (helper/update-route routes
-                 {:path path
-                  :handlers {"GET" get-handler
-                             "HEAD" head-handler}})))
+   (helper/update-route
+     routes
+     {:path path
+      :handlers {"GET" get-handler
+                 "HEAD" head-handler}})))
+
+(defn POST [routes path handler]
+  (helper/update-route
+    routes
+    {:path path
+     :handlers {"POST" handler}}))

--- a/src/http_clj/router.clj
+++ b/src/http_clj/router.clj
@@ -1,56 +1,9 @@
 (ns http-clj.router
-  (:require [http-clj.request-handler :as handler])
-  (:import java.util.regex.Pattern))
-
-(defmulti path-matches?
-  (fn [path route-path]
-    [(type path) (type route-path)]))
-
-(defmethod path-matches? [String String]
-  [path route-path]
-  (= path route-path))
-
-(defmethod path-matches? [String Pattern]
-  [path route-path]
-  (not (nil? (re-matches route-path path))))
-
-(defmethod path-matches? [Pattern Pattern]
-  [path route-path]
-  (= (.pattern path) (.pattern route-path)))
-
-(defmethod path-matches? [Pattern String]
-  [_ _]
-  ; A pattern should not match to a string in this direction
-  ; For instance, #"/.*" will match against the first path it
-  ; encounters instead of matching against a route with the
-  ; #"/.*" path.
-  false)
-
-(defn find-route [routes path]
-  (first (filter #(path-matches? path (:path %)) routes)))
-
-(defn- associate-route-ids [routes]
-  (map-indexed vector routes))
-
-(defn- filter-id-route-pairs-by-path [id-route-pairs path]
-  (filter #(path-matches? path (:path (second %))) id-route-pairs))
-
-(defn- extract-first-id [id-route-pairs]
-  (first (first id-route-pairs)))
-
-(defn- lookup-route-id [routes path]
-  (-> routes
-       associate-route-ids
-       (filter-id-route-pairs-by-path path)
-       extract-first-id))
-
-(defn update-route [routes route]
-  (if-let [route-id (lookup-route-id routes (:path route))]
-    (update routes route-id merge route)
-    (conj routes route)))
+  (:require [http-clj.request-handler :as handler]
+            [http-clj.router.route-helpers :as helper]))
 
 (defn choose-handler [{:keys [path method] :as request} routes]
-  (if-let [route (find-route routes path)]
+  (if-let [route (helper/find-route routes path)]
     (get-in route [:handlers method] handler/method-not-allowed)
     handler/not-found))
 
@@ -66,7 +19,7 @@
         (partial handler/head handler)))
 
   ([routes path get-handler head-handler]
-   (update-route routes
+   (helper/update-route routes
                  {:path path
                   :handlers {"GET" get-handler
                              "HEAD" head-handler}})))

--- a/src/http_clj/router/route_helpers.clj
+++ b/src/http_clj/router/route_helpers.clj
@@ -43,7 +43,10 @@
        (filter-id-route-pairs-by-path path)
        extract-first-id))
 
+(defn- merge-route [old-route new-route]
+  (update old-route :handlers merge (:handlers new-route)))
+
 (defn update-route [routes route]
   (if-let [route-id (lookup-route-id routes (:path route))]
-    (update routes route-id merge route)
+    (update routes route-id merge-route route)
     (conj routes route)))

--- a/src/http_clj/router/route_helpers.clj
+++ b/src/http_clj/router/route_helpers.clj
@@ -1,0 +1,49 @@
+(ns http-clj.router.route-helpers
+  (:import java.util.regex.Pattern))
+
+(defmulti path-matches?
+  (fn [path route-path]
+    [(type path) (type route-path)]))
+
+(defmethod path-matches? [String String]
+  [path route-path]
+  (= path route-path))
+
+(defmethod path-matches? [String Pattern]
+  [path route-path]
+  (not (nil? (re-matches route-path path))))
+
+(defmethod path-matches? [Pattern Pattern]
+  [path route-path]
+  (= (.pattern path) (.pattern route-path)))
+
+(defmethod path-matches? [Pattern String]
+  [_ _]
+  ; A pattern should not match to a string in this direction
+  ; For instance, #"/.*" will match against the first path it
+  ; encounters instead of matching against a route with the
+  ; #"/.*" path.
+  false)
+
+(defn find-route [routes path]
+  (first (filter #(path-matches? path (:path %)) routes)))
+
+(defn- associate-route-ids [routes]
+  (map-indexed vector routes))
+
+(defn- filter-id-route-pairs-by-path [id-route-pairs path]
+  (filter #(path-matches? path (:path (second %))) id-route-pairs))
+
+(defn- extract-first-id [id-route-pairs]
+  (first (first id-route-pairs)))
+
+(defn- lookup-route-id [routes path]
+  (-> routes
+       associate-route-ids
+       (filter-id-route-pairs-by-path path)
+       extract-first-id))
+
+(defn update-route [routes route]
+  (if-let [route-id (lookup-route-id routes (:path route))]
+    (update routes route-id merge route)
+    (conj routes route)))


### PR DESCRIPTION
This adds support for POST requests. Mainly, these changes are focused around being able to read the body the request. Prior to now, the body of the incoming request was disregarded. Because of this new requirement, the way requests were being read/parsed needed some improvements. Mostly this required moving away from reading the request as lines via a `BufferedReader` and dropping down to reading bytes directly from the socket's input stream.
### Summary of the changes and refactorings
- Some of the helpers from `http-clj.router` were extracted into a new ns `http-clj.router.route-helpers`
- The `MockConnection` was removed and is replaced with injecting a mock socket into the existing `SocketConnection`
- `readline` was moved out of the `Connection` protocol and into the `parser` ns.
- The `Connection` protocol has two new method/functions, `read-byte` and `read-bytes`
- Routes for `/form` were added to the cob-spec app.

Apologies for another large PR. I didn't expect it be this large.
### Cob Spec Status

![image](https://cloud.githubusercontent.com/assets/4121849/18146259/4ef17f22-6f94-11e6-918b-5c0da505d542.png)
