### PR TITLE
Refactor request reading & parsing

### DIFF
--- a/spec/http_clj/request/parser_spec.clj
+++ b/spec/http_clj/request/parser_spec.clj
@@ -43,12 +43,35 @@
       (should= "HTTP/1.1" (:version (parser/request-line @get-request)))
       (should= "HTTP/1.1" (:version (parser/request-line @post-request)))))
 
-  (context "parse-headers"
+  (context "headers"
     (before (parser/request-line @get-request))
+    (before (parser/request-line @post-request))
 
-    (it "parses the headers"
+    (it "reads the headers from the connection into a map"
       (should= {"Host" "www.example.com" "User-Agent" "Test-request"}
-               (parser/headers @get-request))))
+               (parser/headers @get-request)))
+
+    (it "parses the header field values"
+         (let [headers (parser/headers @post-request)]
+           (should= 8 (get headers "Content-Length"))))
+
+    (context "read-headers"
+      (it "reads the headers into a list"
+        (should= ["Host: www.example.com" "User-Agent: Test-request"]
+                 (parser/read-headers @get-request))))
+
+    (context "parse-headers"
+      (it "returns an empty map if there are no headers"
+        (should= {} (parser/parse-headers [])))
+      (it "parses the header lines into key-value pairs"
+        (should= {"Host" "www.example.com" "Content-Length" "8"}
+                 (parser/parse-headers ["Host: www.example.com" "Content-Length: 8"]))))
+
+    (context "parse-header-fields"
+        (it "parses Content-Length"
+          (should= {"Content-Length" 9} (parser/parse-header-fields {"Content-Length" "9"}))
+          (should= {"Content-Length" 10 "Host" "www.example.com"}
+                   (parser/parse-header-fields {"Content-Length" "10" "Host" "www.example.com"})))))
 
   (context "read-body"
     (it "is nil if the there is not body to read"

--- a/spec/http_clj/request/parser_spec.clj
+++ b/spec/http_clj/request/parser_spec.clj
@@ -33,28 +33,20 @@
       (should= "HTTP/1.1" (:version (parser/parse-request-line "GET / HTTP/1.1")))
       (should= "HTTP/1.0" (:version (parser/parse-request-line "GET / HTTP/1.0")))))
 
+  (context "parse-headers"
+    (it "returns an empty map if there are no headers"
+      (should= {} (parser/parse-headers [])))
 
-  (context "headers"
-    (before (reader/readline @get-request))
-    (before (reader/readline @post-request))
-
-    (it "reads the headers from the connection into a map"
+    (it "parses the header lines into key-value pairs"
       (should= {"Host" "www.example.com" "User-Agent" "Test-request"}
-               (parser/headers @get-request)))
+               (parser/parse-headers ["Host: www.example.com" "User-Agent: Test-request"])))
 
     (it "parses the header field values"
-         (let [headers (parser/headers @post-request)]
-           (should= 8 (get headers "Content-Length"))))
+      (should= {"Content-Length" 10}
+               (parser/parse-headers ["Content-Length: 10"]))))
 
-    (context "parse-headers"
-      (it "returns an empty map if there are no headers"
-        (should= {} (parser/parse-headers [])))
-      (it "parses the header lines into key-value pairs"
-        (should= {"Host" "www.example.com" "Content-Length" "8"}
-                 (parser/parse-headers ["Host: www.example.com" "Content-Length: 8"]))))
-
-    (context "parse-header-fields"
-        (it "parses Content-Length"
-          (should= {"Content-Length" 9} (parser/parse-header-fields {"Content-Length" "9"}))
-          (should= {"Content-Length" 10 "Host" "www.example.com"}
-                   (parser/parse-header-fields {"Content-Length" "10" "Host" "www.example.com"}))))))
+  (context "parse-header-fields"
+    (it "parses Content-Length"
+      (should= {"Content-Length" 9} (parser/parse-header-fields {"Content-Length" "9"}))
+      (should= {"Content-Length" 10 "Host" "www.example.com"}
+               (parser/parse-header-fields {"Content-Length" "10" "Host" "www.example.com"})))))

--- a/spec/http_clj/request/parser_spec.clj
+++ b/spec/http_clj/request/parser_spec.clj
@@ -7,19 +7,6 @@
             [http-clj.spec-helper.request-generator :refer [GET POST]]))
 
 (describe "request.parser"
-  (with get-request
-    {:conn  (mock/connection
-              (GET "/file1"
-                   {"Host" "www.example.com" "User-Agent" "Test-request"}))})
-
-  (with post-request
-    {:conn (mock/connection
-             (POST "/file2"
-                   {"Host" "www.example.us"
-                    "User-Agent" "Test-request"
-                    "Content-Length" 8}
-                   "var=data"))})
-
   (context "parse-request-line"
     (it "parses the method"
       (should= "GET" (:method (parser/parse-request-line "GET / HTTP/1.1")))

--- a/spec/http_clj/request/reader_spec.clj
+++ b/spec/http_clj/request/reader_spec.clj
@@ -43,11 +43,11 @@
     (it "is nil if the there is not body to read"
       (let [request (-> @get-request
                         (merge  (request/get-request-line @get-request))
-                        (assoc :headers (parser/headers @get-request)))]
+                        (assoc :headers (request/get-headers @get-request)))]
         (should= nil (reader/read-body request))))
 
     (it "returns the body if present"
       (let [request (-> @post-request
                         (merge  (request/get-request-line @post-request))
-                        (assoc :headers (parser/headers@post-request)))]
+                        (assoc :headers (request/get-headers @post-request)))]
         (should= "var=data" (String. (reader/read-body request)))))))

--- a/spec/http_clj/request/reader_spec.clj
+++ b/spec/http_clj/request/reader_spec.clj
@@ -1,0 +1,53 @@
+(ns http-clj.request.reader-spec
+  (:require [speclj.core :refer :all]
+            [http-clj.request :as request]
+            [http-clj.request.reader :as reader]
+            [http-clj.request.parser :as parser]
+            [http-clj.spec-helper.mock :as mock]
+            [http-clj.spec-helper.request-generator :refer [GET POST]]))
+
+(describe "request.reader"
+  (with get-request
+    {:conn  (mock/connection
+              (GET "/file1"
+                   {"Host" "www.example.com" "User-Agent" "Test-request"}))})
+
+  (with post-request
+    {:conn (mock/connection
+             (POST "/file2"
+                   {"Host" "www.example.us"
+                    "User-Agent" "Test-request"
+                    "Content-Length" 8}
+                   "var=data"))})
+
+  (context "readline"
+    (it "reads line delimited by newline characters"
+      (let [conn (mock/connection "one\ntwo")]
+        (should= "one" (reader/readline {:conn conn}))
+        (should= "two" (reader/readline {:conn conn}))))
+
+    (it "reads line delimited by carriage returns"
+      (let [conn (mock/connection "one\r\ntwo")]
+        (should= "one" (reader/readline {:conn conn}))
+        (should= "two" (reader/readline {:conn conn})))))
+
+  (context "read-headers"
+    (before (reader/readline @get-request))
+    (before (reader/readline @post-request))
+
+      (it "reads the headers into a list"
+        (should= ["Host: www.example.com" "User-Agent: Test-request"]
+                 (reader/read-headers @get-request))))
+
+  (context "read-body"
+    (it "is nil if the there is not body to read"
+      (let [request (-> @get-request
+                        (merge  (request/get-request-line @get-request))
+                        (assoc :headers (parser/headers @get-request)))]
+        (should= nil (reader/read-body request))))
+
+    (it "returns the body if present"
+      (let [request (-> @post-request
+                        (merge  (request/get-request-line @post-request))
+                        (assoc :headers (parser/headers@post-request)))]
+        (should= "var=data" (String. (reader/read-body request)))))))

--- a/spec/http_clj/request_spec.clj
+++ b/spec/http_clj/request_spec.clj
@@ -31,6 +31,19 @@
       (should= "HTTP/1.1" (:version (request/get-request-line {:conn @get-conn})))
       (should= "HTTP/1.1" (:version (request/get-request-line {:conn @post-conn})))))
 
+  (context "get-headers"
+    (before (request/get-request-line  {:conn @get-conn}))
+    (before (request/get-request-line {:conn @post-conn}))
+
+    (it "reads the headers from the connection into a map"
+      (should= {"Host" "www.example.com" "User-Agent" "Test-request"}
+               (request/get-headers {:conn @get-conn})))
+
+    (it "parses the header field values"
+      (let [headers (request/get-headers {:conn @post-conn})]
+        (should= 8 (get headers "Content-Length")))))
+
+
   (context "when created"
     (it "has the connection"
       (should= @get-conn (:conn (request/create @get-conn))))

--- a/spec/http_clj/request_spec.clj
+++ b/spec/http_clj/request_spec.clj
@@ -34,12 +34,13 @@
       (should= "HTTP/1.1" (:version (request/create @get-conn)))
       (should= "HTTP/1.1" (:version (request/create @post-conn))))
 
-    (it "has headers"
-      (should= "www.example.com"
-               (get-in (request/create @get-conn) [:headers "Host"]))
-      (should= "www.example.us"
-               (get-in (request/create @post-conn) [:headers "Host"])))
+    (it "has the headers"
+      (let [request (request/create @get-conn)]
+        (should= "www.example.com" (get-in request [:headers "Host"])))
 
-    (it "has a body"
+      (let [request (request/create @post-conn)]
+        (should= 8 (get-in request [:headers "Content-Length"]))))
+
+    (it "has the body"
       (should= nil (:body (request/create @get-conn)))
       (should= "var=data" (String. (:body (request/create @post-conn)))))))

--- a/spec/http_clj/request_spec.clj
+++ b/spec/http_clj/request_spec.clj
@@ -18,6 +18,19 @@
              "Content-Length" 8}
             "var=data")))
 
+  (context "get-request-line"
+    (it "parses the method"
+      (should= "GET" (:method (request/get-request-line {:conn @get-conn})))
+      (should= "POST" (:method (request/get-request-line {:conn @post-conn}))))
+
+    (it "parses the path"
+      (should= "/file1" (:path (request/get-request-line {:conn @get-conn})))
+      (should= "/file2" (:path (request/get-request-line {:conn @post-conn}))))
+
+    (it "parses the version"
+      (should= "HTTP/1.1" (:version (request/get-request-line {:conn @get-conn})))
+      (should= "HTTP/1.1" (:version (request/get-request-line {:conn @post-conn})))))
+
   (context "when created"
     (it "has the connection"
       (should= @get-conn (:conn (request/create @get-conn))))

--- a/src/http_clj/request.clj
+++ b/src/http_clj/request.clj
@@ -10,11 +10,16 @@
        reader/readline
        parser/parse-request-line))
 
+(defn get-headers [request]
+  (-> request
+      reader/read-headers
+      parser/parse-headers))
+
 (defn- attach-request-line [request]
   (merge request (get-request-line request)))
 
 (defn- attach-headers [request]
-  (assoc request :headers (parser/headers request)))
+  (assoc request :headers (get-headers request)))
 
 (defn- attach-body [request]
   (assoc request :body (reader/read-body request)))

--- a/src/http_clj/request.clj
+++ b/src/http_clj/request.clj
@@ -1,7 +1,5 @@
 (ns http-clj.request
-  (:require [http-clj.connection :as connection]
-            [http-clj.logging :as logging]
-            [clojure.string :as string]
+  (:require [clojure.string :as string]
             [http-clj.request.parser :as parser]
             [http-clj.request.reader :as reader]))
 

--- a/src/http_clj/request.clj
+++ b/src/http_clj/request.clj
@@ -2,16 +2,22 @@
   (:require [http-clj.connection :as connection]
             [http-clj.logging :as logging]
             [clojure.string :as string]
-            [http-clj.request.parser :as parser]))
+            [http-clj.request.parser :as parser]
+            [http-clj.request.reader :as reader]))
+
+(defn get-request-line [request]
+  (->> request
+       reader/readline
+       parser/parse-request-line))
 
 (defn- attach-request-line [request]
-  (merge request (parser/request-line request)))
+  (merge request (get-request-line request)))
 
 (defn- attach-headers [request]
   (assoc request :headers (parser/headers request)))
 
 (defn- attach-body [request]
-  (assoc request :body (parser/read-body request)))
+  (assoc request :body (reader/read-body request)))
 
 (defn create [conn]
    (-> {:conn conn}

--- a/src/http_clj/request/parser.clj
+++ b/src/http_clj/request/parser.clj
@@ -1,48 +1,17 @@
 (ns http-clj.request.parser
   (:require [http-clj.connection :as connection]
+            [http-clj.request.reader :as reader]
             [clojure.string :as string]))
 
-(defn- continue-reading? [-byte]
-  (some #(= -byte %) (map int [\newline -1])))
-
-(defn- remove-carriage-returns [-bytes]
-  (remove #(= (int \return) %) -bytes))
-
-(defn- convert-to-string [-bytes]
-  (-> -bytes
-      remove-carriage-returns
-      byte-array
-      String.))
-
-(defn readline [conn]
-    (loop [-bytes []]
-      (let [-byte (connection/read-byte conn)]
-        (if (continue-reading? -byte)
-          (convert-to-string -bytes)
-          (recur (conj -bytes -byte))))))
-
-(defn- split-request-line [conn]
-  (-> conn
-      (readline)
-      (string/split #" ")))
-
-(defn request-line [request]
-  (->> (:conn request)
-       split-request-line
-       (zipmap [:method :path :version])))
+(defn parse-request-line [request-line]
+  (-> request-line
+      (string/split #" ")
+      (#(zipmap [:method :path :version] %))))
 
 (defn- parse-field:value [header]
   (let [[field-name field-value] (string/split header #":")]
     {(string/trim field-name)
      (string/trim field-value)}))
-
-(defn read-headers
-  ([request] (read-headers request []))
-  ([request headers]
-   (let [header (readline (:conn request))]
-     (if (empty? header)
-       headers
-       (recur request (conj headers header))))))
 
 (defn parse-headers [headers]
   (into {} (map parse-field:value headers)))
@@ -54,10 +23,6 @@
 
 (defn headers [request]
   (-> request
-      read-headers
+      reader/read-headers
       parse-headers
       parse-header-fields))
-
-(defn read-body [{:keys [headers conn]}]
-  (if-let [content-length (get headers "Content-Length")]
-    (connection/read-bytes conn content-length)))

--- a/src/http_clj/request/parser.clj
+++ b/src/http_clj/request/parser.clj
@@ -13,16 +13,13 @@
     {(string/trim field-name)
      (string/trim field-value)}))
 
-(defn parse-headers [headers]
-  (into {} (map parse-field:value headers)))
-
 (defn parse-header-fields [headers]
   (if-let [content-length (get headers "Content-Length")]
     (update headers "Content-Length" #(Integer/parseInt %))
     headers))
 
-(defn headers [request]
-  (-> request
-      reader/read-headers
-      parse-headers
+(defn parse-headers [headers]
+  (->> headers
+      (map parse-field:value)
+      (into {} )
       parse-header-fields))

--- a/src/http_clj/request/parser.clj
+++ b/src/http_clj/request/parser.clj
@@ -21,5 +21,5 @@
 (defn parse-headers [headers]
   (->> headers
       (map parse-field:value)
-      (into {} )
+      (into {})
       parse-header-fields))

--- a/src/http_clj/request/reader.clj
+++ b/src/http_clj/request/reader.clj
@@ -1,0 +1,34 @@
+(ns http-clj.request.reader
+  (:require [http-clj.connection :as connection]))
+
+(defn- continue-reading? [-byte]
+  (some #(= -byte %) (map int [\newline -1])))
+
+(defn- remove-carriage-returns [-bytes]
+  (remove #(= (int \return) %) -bytes))
+
+(defn- convert-to-string [-bytes]
+  (-> -bytes
+      remove-carriage-returns
+      byte-array
+      String.))
+
+(defn readline [{conn :conn}]
+    (loop [-bytes []]
+      (let [-byte (connection/read-byte conn)]
+        (if (continue-reading? -byte)
+          (convert-to-string -bytes)
+          (recur (conj -bytes -byte))))))
+
+(defn read-headers
+  ([request] (read-headers request []))
+  ([request headers]
+   (let [header (readline request)]
+     (if (empty? header)
+       headers
+       (recur request (conj headers header))))))
+
+
+(defn read-body [{:keys [headers conn]}]
+  (if-let [content-length (get headers "Content-Length")]
+    (connection/read-bytes conn content-length)))

--- a/src/http_clj/request/reader.clj
+++ b/src/http_clj/request/reader.clj
@@ -28,7 +28,6 @@
        headers
        (recur request (conj headers header))))))
 
-
 (defn read-body [{:keys [headers conn]}]
   (if-let [content-length (get headers "Content-Length")]
     (connection/read-bytes conn content-length)))


### PR DESCRIPTION
The request parsing code was doing too much. It was reading from the connection and parsing the text. This pulls those responsibilities apart.

There is a new ns `http-clj.request.reader` that knows how to read the different parts of the request. `http-clj.request.parser` functions now just take in the string(s) that were read from the the reader. `http-clj.request` will now read and parse each section of the message instead of relying on `http-clj.parser` to do all of the work.
