### PR TITLE
Move format-message to response.formatter

### DIFF
--- a/spec/http_clj/response/formatter_spec.clj
+++ b/spec/http_clj/response/formatter_spec.clj
@@ -1,0 +1,59 @@
+(ns http-clj.response.formatter-spec
+  (:require [speclj.core :refer :all]
+            [http-clj.response.formatter :refer :all]
+            [http-clj.response :as response]
+            [http-clj.spec-helper.mock :as mock]
+            [clojure.string :as string]))
+
+(defn byte-array->string [array]
+  (String. array))
+
+(defn get-status-line [message]
+  (first (string/split (byte-array->string message) #"\r\n")))
+
+(describe "response.formatter"
+  (context "format-message"
+    (with request {:conn (mock/connection)})
+
+    (it "is a valid HTTP response"
+      (let [headers {"Accept" "*" "Host" "www.example.com"}
+            response (response/create @request "Hello, world!" :headers headers)
+            {message :message} (format-message response)]
+        (should= (str "HTTP/1.1 200 OK\r\n"
+                      "Accept: *\r\n"
+                      "Host: www.example.com\r\n"
+                      "\r\n"
+                      "Hello, world!")
+                 (byte-array->string message))))
+
+    (it "formats the headers"
+      (let [headers {"Host" "www.example.com" "Content-Type" "application/json"}
+            response (response/create @request "Message body" :headers headers)
+            {message :message} (format-message response)]
+        (should-contain "Host: www.example.com\r\n" (byte-array->string message))
+        (should-contain "Content-Type: application/json" (byte-array->string message))))
+
+    (it "uses the body from the response"
+      (let [response (response/create @request "Message body")
+            {message :message} (format-message response)]
+        (should-contain "Message body" (byte-array->string message))))
+
+    (it "uses the body from the response"
+      (let [response (response/create @request (.getBytes "Message body"))
+            {message :message} (format-message response)]
+        (should-contain "Message body" (byte-array->string message))))
+
+    (it "uses the status from the response"
+      (let [response (response/create @request "" :status 404)
+            {message :message} (format-message response)]
+        (should-contain "404" (byte-array->string message))))
+
+    (it "has a status line for a GET request"
+      (let [response (response/create @request "" :status 200)
+            {message :message} (format-message response)]
+        (should= "HTTP/1.1 200 OK" (get-status-line message))))
+
+    (it "has a status line for a GET request"
+      (let [response (response/create @request "" :status 404)
+            {message :message} (format-message response)]
+        (should= "HTTP/1.1 404 Not Found" (get-status-line message))))))

--- a/spec/http_clj/response_spec.clj
+++ b/spec/http_clj/response_spec.clj
@@ -1,19 +1,12 @@
 (ns http-clj.response-spec
   (:require [speclj.core :refer :all]
             [http-clj.response :refer :all]
-            [http-clj.spec-helper.mock :refer [connection]]
-            [http-clj.spec-helper.request-generator :refer [GET]]
+            [http-clj.spec-helper.mock :as mock]
             [clojure.string :as string])
   (:import java.io.ByteArrayOutputStream))
 
-(defn byte-array->string [array]
-  (String. array))
-
-(defn get-status-line [message]
-  (first (string/split (byte-array->string message) #"\r\n")))
-
 (describe "a response"
-  (with request {:conn (connection)})
+  (with request {:conn (mock/connection)})
 
   (context "when created"
     (it "has a body"
@@ -33,55 +26,11 @@
     (it "has the connection"
       (should= (:conn @request) (:conn (create @request "")))))
 
-  (context "when composed"
-    (it "is a valid HTTP response"
-      (let [headers {"Accept" "*" "Host" "www.example.com"}
-            response (create @request "Hello, world!" :headers headers)
-            {message :message} (compose response)]
-        (should= (str "HTTP/1.1 200 OK\r\n"
-                      "Accept: *\r\n"
-                      "Host: www.example.com\r\n"
-                      "\r\n"
-                      "Hello, world!")
-                 (byte-array->string message))))
-
-    (it "formats the headers"
-      (let [headers {"Host" "www.example.com" "Content-Type" "application/json"}
-            response (create @request "Message body" :headers headers)
-            {message :message} (compose response)]
-        (should-contain "Host: www.example.com\r\n" (byte-array->string message))
-        (should-contain "Content-Type: application/json" (byte-array->string message))))
-
-    (it "uses the body from the response"
-      (let [response (create @request "Message body")
-            {message :message} (compose response)]
-        (should-contain "Message body" (byte-array->string message))))
-
-    (it "uses the body from the response"
-      (let [response (create @request (.getBytes "Message body"))
-            {message :message} (compose response)]
-        (should-contain "Message body" (byte-array->string message))))
-
-    (it "uses the status from the response"
-      (let [response (create @request "" :status 404)
-            {message :message} (compose response)]
-        (should-contain "404" (byte-array->string message))))
-
-    (it "has a status line for a GET request"
-      (let [response (create @request "" :status 200)
-            {message :message} (compose response)]
-        (should= "HTTP/1.1 200 OK" (get-status-line message))))
-
-    (it "has a status line for a GET request"
-      (let [response (create @request "" :status 404)
-            {message :message} (compose response)]
-        (should= "HTTP/1.1 404 Not Found" (get-status-line message)))))
-
   (context "write"
     (it "writes the HTTP message to the connection"
       (let [output (ByteArrayOutputStream.)
             conn (write {:body "Message body"
                                   :status 200
-                                  :conn (connection "" output)})]
+                                  :conn (mock/connection "" output)})]
         (should-contain "Message body" (.toString output))
         (should-contain "HTTP/1.1 200 OK\r\n" (.toString output))))))

--- a/src/http_clj/response.clj
+++ b/src/http_clj/response.clj
@@ -1,5 +1,6 @@
 (ns http-clj.response
   (:require [clojure.string :as string]
+            [http-clj.response.formatter :as formatter]
             [http-clj.connection :as connection]))
 
 (defn create [request body & {:keys [status headers]
@@ -10,44 +11,8 @@
    :status status
    :conn (:conn request)})
 
-(def reasons
-  {200 "OK"
-   404 "Not Found"})
-
-(def CRLF "\r\n")
-
-(defn- reason-for [status]
-  (get reasons status))
-
-(defn- to-byte-array [string]
-  (byte-array (map (comp byte int) string)))
-
-(defn- format-header [[field-name field-value]]
-  (str field-name ": " field-value CRLF))
-
-(defn- format-headers [headers]
-  (apply str (map format-header headers)))
-
-(defn- generate-status-line [status]
-  (let [version "HTTP/1.1"
-        status status
-        reason (reason-for status)]
-    (str
-      (string/join " " [version status reason])
-      CRLF)))
-
-(defn- generate-message [status headers body]
-  (->> [(generate-status-line status) (format-headers headers) CRLF body]
-       (map to-byte-array)
-       (mapcat seq)
-       (byte-array)))
-
-(defn compose [resp]
-  (let [{status :status headers :headers body :body} resp]
-    (assoc resp :message (generate-message status headers body))))
-
 (defn write [resp]
   (->> resp
-      compose
+      formatter/format-message
       :message
       (connection/write (:conn resp))))

--- a/src/http_clj/response/formatter.clj
+++ b/src/http_clj/response/formatter.clj
@@ -1,0 +1,38 @@
+(ns http-clj.response.formatter
+  (:require [clojure.string :as string]))
+
+(def reasons
+  {200 "OK"
+   404 "Not Found"})
+
+(def CRLF "\r\n")
+
+(defn- reason-for [status]
+  (get reasons status))
+
+(defn- to-byte-array [string]
+  (byte-array (map (comp byte int) string)))
+
+(defn- format-header [[field-name field-value]]
+  (str field-name ": " field-value CRLF))
+
+(defn- format-headers [headers]
+  (apply str (map format-header headers)))
+
+(defn- generate-status-line [status]
+  (let [version "HTTP/1.1"
+        status status
+        reason (reason-for status)]
+    (str
+      (string/join " " [version status reason])
+      CRLF)))
+
+(defn- generate-message [status headers body]
+  (->> [(generate-status-line status) (format-headers headers) CRLF body]
+       (map to-byte-array)
+       (mapcat seq)
+       (byte-array)))
+
+(defn format-message [resp]
+  (let [{status :status headers :headers body :body} resp]
+    (assoc resp :message (generate-message status headers body))))


### PR DESCRIPTION
Simple refactoring which cleans up `http-clj.response`
