### PR TITLE
Header field name to keyword

### DIFF
--- a/spec/http_clj/request/parser_spec.clj
+++ b/spec/http_clj/request/parser_spec.clj
@@ -7,6 +7,7 @@
             [http-clj.spec-helper.request-generator :refer [GET POST]]))
 
 (describe "request.parser"
+  (tags "parser")
   (context "parse-request-line"
     (it "parses the request line into a map"
       (should= {:method "GET" :path "/" :version "HTTP/1.1"}
@@ -22,15 +23,15 @@
       (should= {} (parser/parse-headers [])))
 
     (it "parses the header lines into key-value pairs"
-      (should= {"Host" "www.example.com" "User-Agent" "Test-request"}
+      (should= {:host "www.example.com" :user-agent "Test-request"}
                (parser/parse-headers ["Host: www.example.com" "User-Agent: Test-request"])))
 
     (it "parses the header field values"
-      (should= {"Content-Length" 10}
+      (should= {:content-length 10}
                (parser/parse-headers ["Content-Length: 10"]))))
 
-  (context "parse-header-fields"
+  (context "parse-field-values"
     (it "parses Content-Length"
-      (should= {"Content-Length" 9} (parser/parse-header-fields {"Content-Length" "9"}))
-      (should= {"Content-Length" 10 "Host" "www.example.com"}
-               (parser/parse-header-fields {"Content-Length" "10" "Host" "www.example.com"})))))
+      (should= {:content-length 9} (parser/parse-field-values {:content-length "9"}))
+      (should= {:content-length 10 :host "www.example.com"}
+               (parser/parse-field-values {:content-length "10" :host "www.example.com"})))))

--- a/spec/http_clj/request/reader_spec.clj
+++ b/spec/http_clj/request/reader_spec.clj
@@ -38,5 +38,5 @@
 
     (it "returns the body if present"
       (let [request {:conn (mock/connection "body to read")
-                     :headers {"Content-Length" (alength (.getBytes "body to read"))}}]
+                     :headers {:content-length (alength (.getBytes "body to read"))}}]
         (should= "body to read" (String. (reader/read-body request)))))))

--- a/spec/http_clj/request_spec.clj
+++ b/spec/http_clj/request_spec.clj
@@ -31,10 +31,10 @@
     (before (request/get-request-line {:conn @post-conn}))
 
     (it "reads the headers from the connection into a map"
-      (should= {"Host" "www.example.com" "User-Agent" "Test-request"}
+      (should= {:host "www.example.com" :user-agent "Test-request"}
                (request/get-headers {:conn @get-conn}))
 
-      (should= {"Host" "www.example.us" "Content-Length" 8}
+      (should= {:host "www.example.us" :content-length 8}
                (request/get-headers {:conn @post-conn}))))
 
   (context "when created"
@@ -55,10 +55,10 @@
 
     (it "has the headers"
       (let [request (request/create @get-conn)]
-        (should= "www.example.com" (get-in request [:headers "Host"])))
+        (should= "www.example.com" (get-in request [:headers :host])))
 
       (let [request (request/create @post-conn)]
-        (should= 8 (get-in request [:headers "Content-Length"]))))
+        (should= 8 (get-in request [:headers :content-length]))))
 
     (it "has the body"
       (should= nil (:body (request/create @get-conn)))

--- a/src/http_clj/request/reader.clj
+++ b/src/http_clj/request/reader.clj
@@ -29,5 +29,5 @@
        (recur request (conj headers header))))))
 
 (defn read-body [{:keys [headers conn]}]
-  (if-let [content-length (get headers "Content-Length")]
+  (if-let [content-length (get headers :content-length)]
     (connection/read-bytes conn content-length)))


### PR DESCRIPTION
This normalizes all header field names to make it easier to pull out specific header field values. For example, `"Authorization"` and `"authorization"` are both normalized to `:authorization`.
