### PR TITLE
Basic Authentication

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.cli "0.3.5"]
+                 [org.clojure/data.codec "0.1.0"]
                  [com.stuartsierra/component  "0.3.1"]
                  [clj-http "2.2.0"]
                  [com.taoensso/timbre "4.7.4"]

--- a/spec/http_clj/app/cob_spec/handlers_spec.clj
+++ b/spec/http_clj/app/cob_spec/handlers_spec.clj
@@ -1,7 +1,8 @@
 (ns http-clj.app.cob-spec.handlers-spec
   (:require [speclj.core :refer :all]
             [http-clj.app.cob-spec.handlers :refer :all]
-            [clojure.java.io :as io])
+            [clojure.java.io :as io]
+            [clojure.data.codec.base64 :as b64])
   (:import java.io.ByteArrayOutputStream))
 
 (describe "handlers"
@@ -20,17 +21,18 @@
     (with output (ByteArrayOutputStream.))
     (with request-log (io/writer @output))
 
-    (it "displays the contents of the log"
+    (it "displays the log"
       (.write @request-log "message 1\n")
       (.flush @request-log)
+      (should= 200 (:status (log {} @output)))
       (should-contain "message 1\n" (:body (log {} @output)))))
 
   (context "form"
     (context "submit-form"
-    (it "updates the form"
-      (let [cache (atom "")]
-        (should= 200 (:status (submit-form {:body (.getBytes "submitted=true")} cache)))
-        (should= "submitted=true" @cache))))
+      (it "updates the form"
+        (let [cache (atom "")]
+          (should= 200 (:status (submit-form {:body (.getBytes "submitted=true")} cache)))
+          (should= "submitted=true" @cache))))
 
     (context "last-submission"
       (it "displays the content of the last submission"

--- a/spec/http_clj/app/cob_spec_spec.clj
+++ b/spec/http_clj/app/cob_spec_spec.clj
@@ -55,8 +55,15 @@
   (it "has /image.gif"
     (should= 200 (:status (GET "/image.gif"))))
 
-  (it "has a viewable log"
-    (should-contain "GET /log HTTP/1.1" (:body (GET "/log"))))
+  (it "has a viewable log when authenticated"
+    (let [response (client/get
+                     "http://localhost:5000/logs"
+                     {:basic-auth ["admin" "hunter2"]})]
+      (should-contain "GET /logs HTTP/1.1" (:body response))))
+
+  (it "unauthorized access to the log is not allowed"
+    (let [response (GET "/logs")]
+      (should= 401 (:status response))))
 
   (it "data can be posted to /form"
     (let [{status :status} (POST "/form" {:form-data true})]

--- a/spec/http_clj/response/formatter_spec.clj
+++ b/spec/http_clj/response/formatter_spec.clj
@@ -16,22 +16,22 @@
     (with request {:conn (mock/connection)})
 
     (it "is a valid HTTP response"
-      (let [headers {"Accept" "*" "Host" "www.example.com"}
+      (let [headers {:accept "*" :host "www.example.com"}
             response (response/create @request "Hello, world!" :headers headers)
             {message :message} (format-message response)]
         (should= (str "HTTP/1.1 200 OK\r\n"
-                      "Accept: *\r\n"
-                      "Host: www.example.com\r\n"
+                      "accept: *\r\n"
+                      "host: www.example.com\r\n"
                       "\r\n"
                       "Hello, world!")
                  (byte-array->string message))))
 
     (it "formats the headers"
-      (let [headers {"Host" "www.example.com" "Content-Type" "application/json"}
+      (let [headers {:host "www.example.com" :content-type "application/json"}
             response (response/create @request "Message body" :headers headers)
             {message :message} (format-message response)]
-        (should-contain "Host: www.example.com\r\n" (byte-array->string message))
-        (should-contain "Content-Type: application/json" (byte-array->string message))))
+        (should-contain "host: www.example.com\r\n" (byte-array->string message))
+        (should-contain "content-type: application/json" (byte-array->string message))))
 
     (it "uses the body from the response"
       (let [response (response/create @request "Message body")

--- a/spec/http_clj/response_spec.clj
+++ b/spec/http_clj/response_spec.clj
@@ -20,8 +20,8 @@
       (should= {} (:headers (create @request ""))))
 
     (it "can be provided with headers"
-      (let [{headers :headers} (create @request "" :headers {"Content-Type" "text/html"})]
-        (should= {"Content-Type" "text/html"} headers)))
+      (let [{headers :headers} (create @request "" :headers {:content-type "text/html"})]
+        (should= {:content-type "text/html"} headers)))
 
     (it "has the connection"
       (should= (:conn @request) (:conn (create @request "")))))

--- a/src/http_clj/app/cob_spec.clj
+++ b/src/http_clj/app/cob_spec.clj
@@ -2,6 +2,7 @@
   (:require [http-clj.router :refer [route GET POST OPTIONS]]
             [http-clj.server :refer [run]]
             [http-clj.app.cob-spec.handlers :as handlers]
+            [http-clj.request-handler :refer [auth]]
             [http-clj.app.cob-spec.cli :as cli]
             [http-clj.app.cob-spec.logging :as logger]
             [clojure.java.io :as io]
@@ -15,7 +16,7 @@
   (route
     request
     (-> []
-       (GET "/log" #(handlers/log % log))
+       (GET "/logs"  (auth  #(handlers/log % log) "admin" "hunter2"))
        (POST "/form" #(handlers/submit-form % form-cache))
        (GET "/form" #(handlers/last-submission % form-cache))
        (OPTIONS "/method_options" (handlers/options "GET" "HEAD" "POST" "OPTIONS" "PUT"))

--- a/src/http_clj/app/cob_spec/handlers.clj
+++ b/src/http_clj/app/cob_spec/handlers.clj
@@ -2,6 +2,7 @@
   (:require [http-clj.request-handler :as handler]
             [http-clj.file :as file-helper]
             [http-clj.response :as response]
+            [clojure.data.codec.base64 :as b64]
             [clojure.string :as string]))
 
 (defn static [request directory]
@@ -11,7 +12,7 @@
           :else (handler/not-found request))))
 
 (defn log [request log]
-  (response/create request (.toString log)))
+    (response/create request (.toString log) :status 200))
 
 (defn submit-form [request cache]
   (reset! cache (String. (:body request)))

--- a/src/http_clj/request_handler.clj
+++ b/src/http_clj/request_handler.clj
@@ -2,7 +2,9 @@
   (:require [http-clj.file :as f]
             [http-clj.response :as response]
             [http-clj.presentation.template :as template]
-            [http-clj.presentation.presenter :as presenter]))
+            [http-clj.presentation.presenter :as presenter]
+            [clojure.data.codec.base64 :as b64]
+            [clojure.string :as string]))
 
 (defn directory [request dir]
   (let [files (presenter/files request (.listFiles dir))
@@ -13,6 +15,29 @@
   (-> request
       handler
       (assoc :body nil)))
+
+(defn- matches? [parsed-credentials username password]
+  (let [[parsed-username parsed-password] (string/split parsed-credentials #":")]
+    (and (= parsed-username username) (= parsed-password password))))
+
+(defn- authenticate [{headers :headers} username password]
+  (if-let [authorization (:authorization headers)]
+    (-> authorization
+        (string/split #" ")
+        second
+        .getBytes
+        b64/decode
+        String.
+        (matches? username password))
+    false))
+
+(defn auth [handler username password]
+  (fn [request]
+    (if (authenticate request username password)
+      (handler request)
+      (response/create request ""
+                       :status 401
+                       :headers {:www-authenticate "Basic realm=\"simple\""}))))
 
 (defn not-found [request]
   (response/create request "Not Found" :status 404))

--- a/src/http_clj/response/formatter.clj
+++ b/src/http_clj/response/formatter.clj
@@ -14,7 +14,7 @@
   (byte-array (map (comp byte int) string)))
 
 (defn- format-header [[field-name field-value]]
-  (str field-name ": " field-value CRLF))
+  (str (name field-name) ": " field-value CRLF))
 
 (defn- format-headers [headers]
   (apply str (map format-header headers)))


### PR DESCRIPTION
This adds an `auth` handler which decorate another handler. If authentication is succesful, the request is dispatched to the handler, otherwise it responds with a `401`.

Additionally, I modified the response formatter to accept keywords or strings as header field names.
#### Cob Spec

Now Basic Auth Passes 🎉 
![image](https://cloud.githubusercontent.com/assets/4121849/18259335/889808be-73a8-11e6-850c-2608eee53be2.png)
