### PR TITLE
Partial content

### DIFF
--- a/spec/http_clj/app/cob_spec_spec.clj
+++ b/spec/http_clj/app/cob_spec_spec.clj
@@ -55,6 +55,9 @@
   (it "has /image.gif"
     (should= 200 (:status (GET "/image.gif"))))
 
+  (it "can get partial contents of file.txt"
+    (should= 206 (:status (client/get "http://localhost:5000/file.txt" {:headers {:range "bytes=0-4"}}))))
+
   (it "has a viewable log when authenticated"
     (let [response (client/get
                      "http://localhost:5000/logs"

--- a/spec/http_clj/file_spec.clj
+++ b/spec/http_clj/file_spec.clj
@@ -3,6 +3,7 @@
             [http-clj.file :as file]))
 
 (describe "file"
+  (tags "file")
   (with test-path "/tmp/http-clj-test-file")
   (before (spit @test-path ""))
 
@@ -31,7 +32,11 @@
 
     (it "reads the last n bytes when end is nil"
       (let [byte-range (file/binary-slurp-range @test-path 5 nil)]
-        (should= "a range of bytes" (String. byte-range)))))
+        (should= "a range of bytes" (String. byte-range))))
+
+    (it "raises an exception if offset is outside of the length of the file"
+      (should-throw clojure.lang.ExceptionInfo
+                    (file/binary-slurp-range @test-path 0 5000))))
 
   (context "file-helper"
     (it "takes two paths"

--- a/spec/http_clj/file_spec.clj
+++ b/spec/http_clj/file_spec.clj
@@ -23,7 +23,15 @@
 
     (it "can read bytes 1 through 4 of the file"
       (let [byte-range (file/binary-slurp-range @test-path 1 4)]
-        (should= "ead " (String. byte-range)))))
+        (should= "ead " (String. byte-range))))
+
+    (it "reads the last n bytes when start is nil"
+      (let [byte-range (file/binary-slurp-range @test-path nil 5)]
+        (should= "bytes" (String. byte-range))))
+
+    (it "reads the last n bytes when end is nil"
+      (let [byte-range (file/binary-slurp-range @test-path 5 nil)]
+        (should= "a range of bytes" (String. byte-range)))))
 
   (context "file-helper"
     (it "takes two paths"

--- a/spec/http_clj/file_spec.clj
+++ b/spec/http_clj/file_spec.clj
@@ -3,23 +3,25 @@
             [http-clj.file :as file]))
 
 (describe "file"
+  (with test-path "/tmp/http-clj-test-file")
+  (before (spit @test-path ""))
+
   (context "binary-slurp"
-    (with test-path "/tmp/http-clj-test-file")
-    (before (spit @test-path ""))
+    (with contents "the quick brown fox")
+    (before (spit @test-path @contents))
 
     (it "reads the file contents into a byte-array"
-      (let [data "this quick brown fox"]
-        (spit @test-path data)
-        (should=
-          (seq (.getBytes data))
-          (seq (file/binary-slurp @test-path))))))
+      (should= (seq (.getBytes @contents))
+               (seq (file/binary-slurp @test-path)))))
 
   (context "file-helper"
     (it "takes two paths"
       (file/resolve "resources/static" "image.gif"))
 
     (it "it forms the path correctly"
-      (should= "resources/static/image.gif" (.getPath (file/resolve "resources/static/" "/image.gif"))))
+      (should= "resources/static/image.gif"
+               (.getPath (file/resolve "resources/static/" "/image.gif"))))
 
     (it "returns a file at the requsted path"
-      (should= "resources/static/image.gif" (.getPath (file/resolve "resources/static" "image.gif"))))))
+      (should= "resources/static/image.gif"
+               (.getPath (file/resolve "resources/static" "image.gif"))))))

--- a/spec/http_clj/file_spec.clj
+++ b/spec/http_clj/file_spec.clj
@@ -14,6 +14,17 @@
       (should= (seq (.getBytes @contents))
                (seq (file/binary-slurp @test-path)))))
 
+  (context "binary-slurp-range"
+    (before (spit @test-path "Read a range of bytes"))
+
+    (it "can read the first 4 bytes of a file"
+      (let [byte-range (file/binary-slurp-range @test-path 0 3)]
+        (should= "Read" (String. byte-range))))
+
+    (it "can read bytes 1 through 4 of the file"
+      (let [byte-range (file/binary-slurp-range @test-path 1 4)]
+        (should= "ead " (String. byte-range)))))
+
   (context "file-helper"
     (it "takes two paths"
       (file/resolve "resources/static" "image.gif"))

--- a/spec/http_clj/request/parser_spec.clj
+++ b/spec/http_clj/request/parser_spec.clj
@@ -34,4 +34,10 @@
     (it "parses Content-Length"
       (should= {:content-length 9} (parser/parse-field-values {:content-length "9"}))
       (should= {:content-length 10 :host "www.example.com"}
-               (parser/parse-field-values {:content-length "10" :host "www.example.com"})))))
+               (parser/parse-field-values {:content-length "10" :host "www.example.com"})))
+
+    (it "parses Range"
+      (should= {:range {:units "bytes" :start 0 :end 4}}
+               (parser/parse-field-values {:range "bytes=0-4"}))
+      (should= {:range {:units "bytes" :start 55 :end 60}}
+               (parser/parse-field-values {:range "bytes=55-60"})))))

--- a/spec/http_clj/request/parser_spec.clj
+++ b/spec/http_clj/request/parser_spec.clj
@@ -39,5 +39,5 @@
     (it "parses Range"
       (should= {:range {:units "bytes" :start 0 :end 4}}
                (parser/parse-field-values {:range "bytes=0-4"}))
-      (should= {:range {:units "bytes" :start 55 :end 60}}
-               (parser/parse-field-values {:range "bytes=55-60"})))))
+      (should= {:range {:units "bytes" :start nil :end 60}}
+               (parser/parse-field-values {:range "bytes=-60"})))))

--- a/spec/http_clj/request_handler/filesystem_spec.clj
+++ b/spec/http_clj/request_handler/filesystem_spec.clj
@@ -1,0 +1,46 @@
+(ns http-clj.request-handler.filesystem-spec
+  (:require [speclj.core :refer :all]
+            [http-clj.request-handler.filesystem :as handler]
+            [http-clj.response :as response]
+            [hiccup.core :refer [html]]
+            [clojure.java.io :as io])
+  (:import java.io.File))
+
+
+(defn mock-directory []
+  (proxy [File] [""]
+    (listFiles []
+      (into-array [(io/file "file-a")
+                   (io/file "file-b")
+                   (io/file "subdirectory")]))
+    (isDirectory []
+      true)))
+
+(describe "request-handler.filesystem"
+  (context "directory"
+    (it "has a text/html content type"
+      (let [{headers :headers} (handler/directory {:path "/"} (mock-directory))]
+        (should= "text/html" (get headers "Content-Type"))))
+
+    (it "lists the contents of the directory"
+      (let [{body :body} (handler/directory {:path "/"} (mock-directory))]
+        (should-contain (html [:a {:href "/file-a"} "file-a"]) body)
+        (should-contain (html [:a {:href "/file-b"} "file-b"]) body)
+        (should-contain (html [:a {:href "/subdirectory"} "subdirectory"]) body)))
+
+    (it "paths to the files are relative to the request path"
+      (let [{body :body} (handler/directory {:path "/dir"} (mock-directory))]
+        (should-contain (html [:a {:href "/dir/file-a"} "file-a"]) body))))
+
+  (context "file"
+    (with test-path "/tmp/http-clj-test-file-handler")
+    (with test-data "Some content")
+    (before-all (spit @test-path @test-data))
+
+    (it "returns a handler when given just a path"
+      (let [{message :body} ((handler/file @test-path) {})]
+        (should= (seq message) (seq (.getBytes @test-data)))))
+
+    (it "can accept a request and a file object"
+      (let [{message :body} (handler/file {} (io/file @test-path))]
+        (should= (seq message) (seq (.getBytes @test-data)))))))

--- a/spec/http_clj/request_handler/filesystem_spec.clj
+++ b/spec/http_clj/request_handler/filesystem_spec.clj
@@ -58,10 +58,10 @@
 
     (context "file"
       (it "can accept a request and a file object"
-        (let [{message :body} (handler/file {} (io/file @test-path))]
+        (let [{message :body} (handler/file {} @test-path)]
           (should= (seq message) (seq (.getBytes @test-data)))))
 
       (it "it uses partial-file if a range is provided"
         (let [request {:headers {:range {:start 0 :end 0}}}]
           (should-invoke handler/partial-file {:times 1}
-                         (handler/file request (io/file @test-path))))))))
+                         (handler/file request @test-path)))))))

--- a/spec/http_clj/request_handler/filesystem_spec.clj
+++ b/spec/http_clj/request_handler/filesystem_spec.clj
@@ -32,25 +32,36 @@
       (let [{body :body} (handler/directory {:path "/dir"} (mock-directory))]
         (should-contain (html [:a {:href "/dir/file-a"} "file-a"]) body))))
 
-  (context "file"
+  (describe "file handlers"
     (with test-path "/tmp/http-clj-test-file-handler")
     (with test-data "Some content")
     (before-all (spit @test-path @test-data))
 
-    (it "can accept a request and a file object"
-      (let [{message :body} (handler/file {} (io/file @test-path))]
-        (should= (seq message) (seq (.getBytes @test-data)))))
+    (context "partial-file"
+      (it "responds with a 206 if a range is provided"
+        (let [request {:headers {:range {:start 0 :end 0}}}
+              resp (handler/partial-file request @test-path)]
+          (should= 206 (:status resp))))
 
-    (it "responds with a 206 if a range is provided"
-      (let [request {:headers {:range {:start 0 :end 0}}}
-            resp (handler/file request (io/file @test-path))]
-        (should= 206 (:status resp))))
+      (it "it has the requested range in the body"
+        (let [request {:headers {:range {:start 0 :end 3}}}
+              resp (handler/partial-file request @test-path)]
+          (should= "Some" (String. (:body resp))))
 
-    (it "it has the requested range in the body"
-      (let [request {:headers {:range {:start 0 :end 3}}}
-            resp (handler/file request (io/file @test-path))]
-        (should= "Some" (String. (:body resp))))
+        (let [request {:headers {:range {:start 1 :end 3}}}
+              resp (handler/partial-file request @test-path)]
+          (should= "ome" (String. (:body resp)))))
+      (it "responds with a 416 if the range is not satisfiable"
+        (let [request {:headers {:range {:start 1 :end 500}}}
+              resp (handler/partial-file request @test-path)]
+          (should= 416 (:status resp)))))
 
-      (let [request {:headers {:range {:start 1 :end 3}}}
-            resp (handler/file request (io/file @test-path))]
-        (should= "ome" (String. (:body resp)))))))
+    (context "file"
+      (it "can accept a request and a file object"
+        (let [{message :body} (handler/file {} (io/file @test-path))]
+          (should= (seq message) (seq (.getBytes @test-data)))))
+
+      (it "it uses partial-file if a range is provided"
+        (let [request {:headers {:range {:start 0 :end 0}}}]
+          (should-invoke handler/partial-file {:times 1}
+                         (handler/file request (io/file @test-path))))))))

--- a/spec/http_clj/request_handler_spec.clj
+++ b/spec/http_clj/request_handler_spec.clj
@@ -18,21 +18,6 @@
       true)))
 
 (describe "handler"
-  (context "directory"
-    (it "has a text/html content type"
-      (let [{headers :headers} (handler/directory {:path "/"} (mock-directory))]
-        (should= "text/html" (get headers "Content-Type"))))
-
-    (it "lists the contents of the directory"
-      (let [{body :body} (handler/directory {:path "/"} (mock-directory))]
-        (should-contain (html [:a {:href "/file-a"} "file-a"]) body)
-        (should-contain (html [:a {:href "/file-b"} "file-b"]) body)
-        (should-contain (html [:a {:href "/subdirectory"} "subdirectory"]) body))))
-
-  (it "paths to the files are relative to the request path"
-    (let [{body :body} (handler/directory {:path "/dir"} (mock-directory))]
-      (should-contain (html [:a {:href "/dir/file-a"} "file-a"]) body)))
-
   (context "not-found"
     (it "responds with status code 404"
       (should= 404 (:status (handler/not-found {}))))
@@ -46,19 +31,6 @@
 
     (it "has Method Not Allowed in the body"
       (should= "Method Not Allowed" (:body (handler/method-not-allowed {})))))
-
-  (context "file"
-    (with test-path "/tmp/http-clj-test-file-handler")
-    (with test-data "Some content")
-    (before-all (spit @test-path @test-data))
-
-    (it "returns a handler when given just a path"
-      (let [{message :body} ((handler/file @test-path) {})]
-        (should= (seq message) (seq (.getBytes @test-data)))))
-
-    (it "can accept a request and a file object"
-      (let [{message :body} (handler/file {} (io/file @test-path))]
-        (should= (seq message) (seq (.getBytes @test-data))))))
 
   (context "head"
     (it "returns a resp with the body stripped out"

--- a/src/http_clj/app/cob_spec/handlers.clj
+++ b/src/http_clj/app/cob_spec/handlers.clj
@@ -1,5 +1,6 @@
 (ns http-clj.app.cob-spec.handlers
   (:require [http-clj.request-handler :as handler]
+            [http-clj.request-handler.filesystem :as filesystem]
             [http-clj.file :as file-helper]
             [http-clj.response :as response]
             [clojure.data.codec.base64 :as b64]
@@ -7,8 +8,8 @@
 
 (defn static [request directory]
   (let [file (file-helper/resolve directory (:path request))]
-    (cond (.isDirectory file) (handler/directory request file)
-          (.exists file) (handler/file request file)
+    (cond (.isDirectory file) (filesystem/directory request file)
+          (.exists file) (filesystem/file request file)
           :else (handler/not-found request))))
 
 (defn log [request log]

--- a/src/http_clj/app/cob_spec/handlers.clj
+++ b/src/http_clj/app/cob_spec/handlers.clj
@@ -9,7 +9,7 @@
 (defn static [request directory]
   (let [file (file-helper/resolve directory (:path request))]
     (cond (.isDirectory file) (filesystem/directory request file)
-          (.exists file) (filesystem/file request file)
+          (.exists file) (filesystem/file request (.getPath file))
           :else (handler/not-found request))))
 
 (defn log [request log]

--- a/src/http_clj/file.clj
+++ b/src/http_clj/file.clj
@@ -25,14 +25,23 @@
         start (inc (- size end))]
     (binary-slurp-range path start size)))
 
-(defmethod binary-slurp-range [Number Number]
-  [path start end]
+(defn- -binary-slurp-range [path start end]
   (let [buffer-size (inc (- end start))
         buffer (byte-array buffer-size)]
     (with-open [stream (io/input-stream path)]
       (.skip stream start)
       (.read stream buffer))
     buffer))
+
+(defn- valid-range? [path start end]
+  (let [size (-> (File. path) .length dec)]
+    (and (<= start size) (<= end size))))
+
+(defmethod binary-slurp-range [Number Number]
+  [path start end]
+  (when (not (valid-range? path start end))
+    (throw (ex-info "Range Unsatisfiable" {:cause :unsatisfiable})))
+  (-binary-slurp-range path start end))
 
 (defn resolve [root-dir path]
   (-> (Paths/get root-dir (into-array [path]))

--- a/src/http_clj/file.clj
+++ b/src/http_clj/file.clj
@@ -10,7 +10,23 @@
       .toPath
       Files/readAllBytes))
 
-(defn binary-slurp-range [path start end]
+(defmulti binary-slurp-range
+  (fn [_ start end]
+    [(type start) (type end)]))
+
+(defmethod binary-slurp-range [Number nil]
+  [path start _]
+  (let [size (dec (.length (File. path)))]
+    (binary-slurp-range path start size)))
+
+(defmethod binary-slurp-range [nil Number]
+  [path _ end]
+  (let [size (dec (.length (File. path)))
+        start (inc (- size end))]
+    (binary-slurp-range path start size)))
+
+(defmethod binary-slurp-range [Number Number]
+  [path start end]
   (let [buffer-size (inc (- end start))
         buffer (byte-array buffer-size)]
     (with-open [stream (io/input-stream path)]

--- a/src/http_clj/file.clj
+++ b/src/http_clj/file.clj
@@ -1,4 +1,5 @@
 (ns http-clj.file
+  (:require [clojure.java.io :as io])
   (:import java.io.File
            java.nio.file.Files
            java.nio.file.Paths))
@@ -8,6 +9,14 @@
       File.
       .toPath
       Files/readAllBytes))
+
+(defn binary-slurp-range [path start end]
+  (let [buffer-size (inc (- end start))
+        buffer (byte-array buffer-size)]
+    (with-open [stream (io/input-stream path)]
+      (.skip stream start)
+      (.read stream buffer))
+    buffer))
 
 (defn resolve [root-dir path]
   (-> (Paths/get root-dir (into-array [path]))

--- a/src/http_clj/request/parser.clj
+++ b/src/http_clj/request/parser.clj
@@ -32,10 +32,15 @@
 (defn- to-range-map [split-fields]
   (zipmap [:units :start :end] split-fields))
 
+(defn- parse-byte-position [position]
+  (try
+    (Integer/parseInt position)
+    (catch java.lang.NumberFormatException _ nil)))
+
 (defn- parse-start-end [range-map]
   (-> range-map
-      (update :start #(Integer/parseInt %))
-      (update :end #(Integer/parseInt %))))
+      (update :start parse-byte-position)
+      (update :end parse-byte-position)))
 
 (defn- parse-range [field-value]
   (-> field-value

--- a/src/http_clj/request/parser.clj
+++ b/src/http_clj/request/parser.clj
@@ -26,10 +26,32 @@
       lower-case-field-name
       field-name->keyword))
 
-(defn parse-field-values [headers]
-  (if-let [content-length (get headers :content-length)]
-    (update headers :content-length #(Integer/parseInt %))
+(defn- split-range-header [field-value]
+  (string/split field-value #"=|-"))
+
+(defn- to-range-map [split-fields]
+  (zipmap [:units :start :end] split-fields))
+
+(defn- parse-start-end [range-map]
+  (-> range-map
+      (update :start #(Integer/parseInt %))
+      (update :end #(Integer/parseInt %))))
+
+(defn- parse-range [field-value]
+  (-> field-value
+      split-range-header
+      to-range-map
+      parse-start-end))
+
+(defn parse-field-value [headers field-name parser]
+  (if-let [field-value (field-name headers)]
+    (update headers field-name parser)
     headers))
+
+(defn parse-field-values [headers]
+  (-> headers
+      (parse-field-value :content-length #(Integer/parseInt %))
+      (parse-field-value :range parse-range)))
 
 (defn parse-headers [headers]
   (->> headers

--- a/src/http_clj/request_handler.clj
+++ b/src/http_clj/request_handler.clj
@@ -6,11 +6,6 @@
             [clojure.data.codec.base64 :as b64]
             [clojure.string :as string]))
 
-(defn directory [request dir]
-  (let [files (presenter/files request (.listFiles dir))
-        html (template/directory files)]
-  (response/create request html :headers {"Content-Type" "text/html"})))
-
 (defn head [handler request]
   (-> request
       handler
@@ -44,9 +39,3 @@
 
 (defn method-not-allowed [request]
   (response/create request "Method Not Allowed" :status 405))
-
-(defn file
-  ([request io-file] ((file (.getPath io-file)) request))
-  ([path]
-   (fn [request]
-     (response/create request (f/binary-slurp path)))))

--- a/src/http_clj/request_handler/filesystem.clj
+++ b/src/http_clj/request_handler/filesystem.clj
@@ -9,8 +9,15 @@
         html (template/directory files)]
     (response/create request html :headers {"Content-Type" "text/html"})))
 
+(defn partial-file [request path]
+  (let [{start :start end :end} (get-in request [:headers :range])]
+    (try
+      (response/create request (f/binary-slurp-range path start end) :status 206)
+      (catch clojure.lang.ExceptionInfo e
+        (response/create request "" :status 416)))))
+
 (defn file [{:keys [headers] :as request} io-file]
   (let [path (.getPath io-file)]
-    (if-let [{start :start end :end} (:range headers)]
-      (response/create request (f/binary-slurp-range path start end) :status 206)
+    (if (not-empty (:range headers))
+      (partial-file request path)
       (response/create request (f/binary-slurp path)))))

--- a/src/http_clj/request_handler/filesystem.clj
+++ b/src/http_clj/request_handler/filesystem.clj
@@ -16,8 +16,7 @@
       (catch clojure.lang.ExceptionInfo e
         (response/create request "" :status 416)))))
 
-(defn file [{:keys [headers] :as request} io-file]
-  (let [path (.getPath io-file)]
-    (if (not-empty (:range headers))
+(defn file [{:keys [headers] :as request} path]
+  (if (not-empty (:range headers))
       (partial-file request path)
-      (response/create request (f/binary-slurp path)))))
+      (response/create request (f/binary-slurp path))))

--- a/src/http_clj/request_handler/filesystem.clj
+++ b/src/http_clj/request_handler/filesystem.clj
@@ -4,15 +4,13 @@
             [http-clj.presentation.template :as template]
             [http-clj.presentation.presenter :as presenter]))
 
-
 (defn directory [request dir]
   (let [files (presenter/files request (.listFiles dir))
         html (template/directory files)]
-  (response/create request html :headers {"Content-Type" "text/html"})))
+    (response/create request html :headers {"Content-Type" "text/html"})))
 
-
-(defn file
-  ([request io-file] ((file (.getPath io-file)) request))
-  ([path]
-   (fn [request]
-     (response/create request (f/binary-slurp path)))))
+(defn file [{:keys [headers] :as request} io-file]
+  (let [path (.getPath io-file)]
+    (if-let [{start :start end :end} (:range headers)]
+      (response/create request (f/binary-slurp-range path start end) :status 206)
+      (response/create request (f/binary-slurp path)))))

--- a/src/http_clj/request_handler/filesystem.clj
+++ b/src/http_clj/request_handler/filesystem.clj
@@ -1,0 +1,18 @@
+(ns http-clj.request-handler.filesystem
+  (:require [http-clj.file :as f]
+            [http-clj.response :as response]
+            [http-clj.presentation.template :as template]
+            [http-clj.presentation.presenter :as presenter]))
+
+
+(defn directory [request dir]
+  (let [files (presenter/files request (.listFiles dir))
+        html (template/directory files)]
+  (response/create request html :headers {"Content-Type" "text/html"})))
+
+
+(defn file
+  ([request io-file] ((file (.getPath io-file)) request))
+  ([path]
+   (fn [request]
+     (response/create request (f/binary-slurp path)))))


### PR DESCRIPTION
These changes add support for range requests.

I added a function `binary-slurp-range` that can handle the different position offsets of a Range header value. (i.e. `-500`, `9500-`, and `0-500`). The `file` handler is now checking if the request is a range request, and serving the partial content, or serving the whole file.

I also updated the request parser to parse the range field-value into a map

``` clojure
{:units "bytes" :start 0 :end 50}
{:units "bytes" :start nil :end 50}
```
### Cob Spec

🎉 Partial Content! 🎉 

![image](https://cloud.githubusercontent.com/assets/4121849/18280683/8257393a-741f-11e6-946e-92617d7733d6.png)
