### PR TITLE
Catch ConnectExceptions when shutting down the server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: clojure
-script: travis_retry lein spec
+script: lein spec -f documentation

--- a/spec/http_clj/app/cob_spec_spec.clj
+++ b/spec/http_clj/app/cob_spec_spec.clj
@@ -20,9 +20,16 @@
     (.await latch)
     thread))
 
+(defn stop-listening []
+  (try
+    (client/get root)
+    (catch java.net.ConnectException e
+      (println "Server already shutdown"))))
+
 (defn shutdown-server [thread]
   (.interrupt thread)
-  (client/get root))
+  (when (.isAlive thread)
+    (stop-listening)))
 
 (defn GET [path]
   (client/get (str root path) {:throw-exceptions false}))


### PR DESCRIPTION
It is possible for the server thread to end before its next call to `accept`. In such a scenario, a `java.net.ConnectException` is thrown. This exception is now being caught. Additionally, the shutdown function is checking if the thread is still alive before attempting to stop it from listening.

This will actually fix #14 
