### PR TITLE
Patch Requests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.cli "0.3.5"]
                  [org.clojure/data.codec "0.1.0"]
+                 [digest "1.4.4"]
                  [com.stuartsierra/component  "0.3.1"]
                  [clj-http "2.2.0"]
                  [com.taoensso/timbre "4.7.4"]

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.cli "0.3.5"]
                  [org.clojure/data.codec "0.1.0"]
+                 [org.clojure/core.match "0.3.0-alpha4"]
                  [digest "1.4.4"]
                  [com.stuartsierra/component  "0.3.1"]
                  [clj-http "2.2.0"]

--- a/spec/http_clj/app/cob_spec_spec.clj
+++ b/spec/http_clj/app/cob_spec_spec.clj
@@ -52,11 +52,18 @@
       (should-contain "file.txt" body)
       (should-contain "image.gif" body)))
 
+  (it "will attempt to patch a static file"
+    (let [resp (client/patch "http:localhost:5000/file.txt" {:headers {:if-match "incorrect-etag"}
+                                                             :throw-exceptions false})]
+      (should= 409 (:status resp))))
+
   (it "has /image.gif"
     (should= 200 (:status (GET "/image.gif"))))
 
   (it "can get partial contents of file.txt"
-    (should= 206 (:status (client/get "http://localhost:5000/file.txt" {:headers {:range "bytes=0-4"}}))))
+    (let [resp (client/get "http://localhost:5000/file.txt"
+                           {:headers {:range "bytes=0-4"}})]
+      (should= 206 (:status resp))))
 
   (it "has a viewable log when authenticated"
     (let [response (client/get

--- a/spec/http_clj/app/cob_spec_spec.clj
+++ b/spec/http_clj/app/cob_spec_spec.clj
@@ -53,8 +53,10 @@
       (should-contain "image.gif" body)))
 
   (it "will attempt to patch a static file"
-    (let [resp (client/patch "http:localhost:5000/file.txt" {:headers {:if-match "incorrect-etag"}
-                                                             :throw-exceptions false})]
+    (let [resp (client/patch
+                 "http:localhost:5000/file.txt"
+                 {:headers {:if-match "incorrect-etag"}
+                  :throw-exceptions false})]
       (should= 409 (:status resp))))
 
   (it "has /image.gif"

--- a/spec/http_clj/entity_spec.clj
+++ b/spec/http_clj/entity_spec.clj
@@ -2,14 +2,11 @@
   (:require [speclj.core :refer :all]
             [http-clj.entity :as entity]
             [digest :refer [sha1]]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io])
+  (:import java.io.File))
 
 (describe "entity"
   (context "tag"
-    (with file "/tmp/http-clj-digest-file")
-    (with content "Test content")
-    (before (spit @file @content))
-
     (it "uses digest.sha1"
       (should-invoke sha1 {:times 1 :with ["content"]}
                      (entity/tag "content")))
@@ -18,8 +15,10 @@
       (should= "5e9b60f69165f32f8930843ca718e10fdee30c52" (entity/tag "tag"))
       (should= "040f06fd774092478d450774f5ba30c5da78acc8" (entity/tag "content")))
 
+    (with file (File/createTempFile "http-clj-digest" ".txt"))
+    (after (.delete @file))
+
     (it "accepts a File"
-      (let [file "/tmp/http-clj-digest-file"
-            content "Test content"]
-        (spit file content)
-        (should= (sha1 "Test content") (entity/tag (io/as-file file)))))))
+      (let [content "Test content"]
+        (spit (.getPath @file) content)
+        (should= (sha1 "Test content") (entity/tag @file))))))

--- a/spec/http_clj/entity_spec.clj
+++ b/spec/http_clj/entity_spec.clj
@@ -1,0 +1,25 @@
+(ns http-clj.entity-spec
+  (:require [speclj.core :refer :all]
+            [http-clj.entity :as entity]
+            [digest :refer [sha1]]
+            [clojure.java.io :as io]))
+
+(describe "entity"
+  (context "tag"
+    (with file "/tmp/http-clj-digest-file")
+    (with content "Test content")
+    (before (spit @file @content))
+
+    (it "uses digest.sha1"
+      (should-invoke sha1 {:times 1 :with ["content"]}
+                     (entity/tag "content")))
+
+    (it "returns the digest"
+      (should= "5e9b60f69165f32f8930843ca718e10fdee30c52" (entity/tag "tag"))
+      (should= "040f06fd774092478d450774f5ba30c5da78acc8" (entity/tag "content")))
+
+    (it "accepts a File"
+      (let [file "/tmp/http-clj-digest-file"
+            content "Test content"]
+        (spit file content)
+        (should= (sha1 "Test content") (entity/tag (io/as-file file)))))))

--- a/spec/http_clj/file_spec.clj
+++ b/spec/http_clj/file_spec.clj
@@ -38,7 +38,7 @@
       (should-throw clojure.lang.ExceptionInfo
                     (file/binary-slurp-range @test-path 0 5000))))
 
-  (context "file-helper"
+  (context "resolve"
     (it "takes two paths"
       (file/resolve "resources/static" "image.gif"))
 

--- a/spec/http_clj/request_handler/filesystem_spec.clj
+++ b/spec/http_clj/request_handler/filesystem_spec.clj
@@ -2,8 +2,8 @@
   (:require [speclj.core :refer :all]
             [http-clj.request-handler.filesystem :as handler]
             [http-clj.response :as response]
+            [http-clj.entity :as entity]
             [hiccup.core :refer [html]]
-            [digest :refer [sha1]]
             [clojure.java.io :as io])
   (:import java.io.File))
 
@@ -74,7 +74,7 @@
           (should= "New content" (slurp @test-path))))
 
       (it "updates the contents of the file if the when the precondition is true"
-        (let [request (assoc-in @request [:headers :if-match] (sha1 @test-data))
+        (let [request (assoc-in @request [:headers :if-match] (entity/tag @test-data))
               resp (handler/patch-file request @test-path)]
           (should= "New content" (slurp @test-path))))
 

--- a/spec/http_clj/router_spec.clj
+++ b/spec/http_clj/router_spec.clj
@@ -111,8 +111,17 @@
         (let [routes (POST @routes "/a" :handler)]
           (should= {:path "/a" :handlers {"POST" :handler}} (first routes)))))
 
+    (context "PATCH"
+      (with routes [{:path "/path" :handlers {"GET" :get-handler}}])
+
+      (it "adds the PATCH handler"
+        (let [routes (PATCH @routes "/path" :patch-handler)]
+          (should= {"PATCH" :patch-handler "GET" :get-handler}
+                   (:handlers (find-route routes "/path"))))))
+
     (context "OPTIONS"
       (with routes [{:path "/path" :handlers {"POST" :post-handler}}])
+
       (it "adds the OPTIONS handler"
         (let [routes (OPTIONS @routes "/path" :options-handler)]
           (should= {"POST" :post-handler "OPTIONS" :options-handler}

--- a/src/http_clj/app/cob_spec.clj
+++ b/src/http_clj/app/cob_spec.clj
@@ -1,5 +1,5 @@
 (ns http-clj.app.cob-spec
-  (:require [http-clj.router :refer [route GET POST OPTIONS]]
+  (:require [http-clj.router :refer [route GET POST OPTIONS PATCH]]
             [http-clj.server :refer [run]]
             [http-clj.app.cob-spec.handlers :as handlers]
             [http-clj.request-handler :refer [auth]]
@@ -21,7 +21,8 @@
        (GET "/form" #(handlers/last-submission % form-cache))
        (OPTIONS "/method_options" (handlers/options "GET" "HEAD" "POST" "OPTIONS" "PUT"))
        (OPTIONS "/method_options2" (handlers/options "GET" "OPTIONS"))
-       (GET #"^/.*$" #(handlers/static % directory)))))
+       (GET #"^/.*$" #(handlers/static % directory))
+       (PATCH #"^/.*$" #(handlers/static % directory)))))
 
 (defn app [directory]
   {:entrypoint #(cob-spec % directory)

--- a/src/http_clj/app/cob_spec/handlers.clj
+++ b/src/http_clj/app/cob_spec/handlers.clj
@@ -7,9 +7,8 @@
             [clojure.data.codec.base64 :as b64]
             [clojure.string :as string]))
 
-(defn static [request directory]
-  (let [file (file-helper/resolve directory (:path request))
-        method (:method request)
+(defn -static [request file]
+  (let [method (:method request)
         directory? (.isDirectory file)
         exists? (.exists file)]
 
@@ -18,6 +17,10 @@
       ["GET" false true] (filesystem/file request (.getPath file))
       ["PATCH" false true] (filesystem/patch-file request (.getPath file))
       [_ _ _] (handler/not-found request))))
+
+(defn static [request directory]
+  (let [file (file-helper/resolve directory (:path request))]
+    (-static request file)))
 
 (defn log [request log]
     (response/create request (.toString log) :status 200))

--- a/src/http_clj/entity.clj
+++ b/src/http_clj/entity.clj
@@ -1,0 +1,5 @@
+(ns http-clj.entity
+  (:require [digest :refer [sha1]]))
+
+(defn tag [content]
+  (sha1 content))

--- a/src/http_clj/request_handler/filesystem.clj
+++ b/src/http_clj/request_handler/filesystem.clj
@@ -1,9 +1,10 @@
 (ns http-clj.request-handler.filesystem
   (:require [http-clj.file :as f]
+            [clojure.java.io :as io]
             [http-clj.response :as response]
             [http-clj.presentation.template :as template]
             [http-clj.presentation.presenter :as presenter]
-            [digest :refer [sha1]]))
+            [http-clj.entity :as entity]
 
 (defn directory [request dir]
   (let [files (presenter/files request (.listFiles dir))
@@ -26,10 +27,9 @@
   (response/create request "" :status 409))
 
 (defn patch-file [{:keys [headers] :as request} file]
-  (let [precondition (:if-match headers)
-        content (f/binary-slurp file)]
+  (let [precondition (:if-match headers)]
     (cond (nil? precondition) (-patch-file request file)
-          (= precondition (sha1 content)) (-patch-file request file)
+          (= precondition (entity/tag (io/as-file file))) (-patch-file request file)
           :else (conflict request))))
 
 (defn file [{:keys [headers] :as request} path]

--- a/src/http_clj/request_handler/filesystem.clj
+++ b/src/http_clj/request_handler/filesystem.clj
@@ -4,7 +4,7 @@
             [http-clj.response :as response]
             [http-clj.presentation.template :as template]
             [http-clj.presentation.presenter :as presenter]
-            [http-clj.entity :as entity]
+            [http-clj.entity :as entity]))
 
 (defn directory [request dir]
   (let [files (presenter/files request (.listFiles dir))
@@ -26,10 +26,13 @@
 (defn- conflict [request]
   (response/create request "" :status 409))
 
+(defn- if-match? [precondition file]
+  (= precondition (entity/tag (io/as-file file))))
+
 (defn patch-file [{:keys [headers] :as request} file]
   (let [precondition (:if-match headers)]
     (cond (nil? precondition) (-patch-file request file)
-          (= precondition (entity/tag (io/as-file file))) (-patch-file request file)
+          (if-match? precondition file) (-patch-file request file)
           :else (conflict request))))
 
 (defn file [{:keys [headers] :as request} path]

--- a/src/http_clj/request_handler/filesystem.clj
+++ b/src/http_clj/request_handler/filesystem.clj
@@ -2,7 +2,8 @@
   (:require [http-clj.file :as f]
             [http-clj.response :as response]
             [http-clj.presentation.template :as template]
-            [http-clj.presentation.presenter :as presenter]))
+            [http-clj.presentation.presenter :as presenter]
+            [digest :refer [sha1]]))
 
 (defn directory [request dir]
   (let [files (presenter/files request (.listFiles dir))
@@ -15,6 +16,21 @@
       (response/create request (f/binary-slurp-range path start end) :status 206)
       (catch clojure.lang.ExceptionInfo e
         (response/create request "" :status 416)))))
+
+(defn- -patch-file [request file]
+  (with-open [stream (clojure.java.io/output-stream file)]
+    (.write stream (:body request)))
+  (response/create request "" :status 204))
+
+(defn- conflict [request]
+  (response/create request "" :status 409))
+
+(defn patch-file [{:keys [headers] :as request} file]
+  (let [precondition (:if-match headers)
+        content (f/binary-slurp file)]
+    (cond (nil? precondition) (-patch-file request file)
+          (= precondition (sha1 content)) (-patch-file request file)
+          :else (conflict request))))
 
 (defn file [{:keys [headers] :as request} path]
   (if (not-empty (:range headers))

--- a/src/http_clj/router.clj
+++ b/src/http_clj/router.clj
@@ -31,6 +31,12 @@
     {:path path
      :handlers {"POST" handler}}))
 
+(defn PATCH [routes path handler]
+  (helper/update-route
+    routes
+    {:path path
+     :handlers {"PATCH" handler}}))
+
 (defn OPTIONS [routes path handler]
   (helper/update-route
     routes


### PR DESCRIPTION
The approach here was to add a new handler, `patch-file`, which knows how to respond to a patch request. (See `http-clj.request-handler.filesystem/patch-file`). From there, I modified the `static` handler inside of `http-clj.app.cob-spec.handlers`, so that it can also handle PATCH request. (I used core.match per your encouragement, @trptcolin. 😄)

This is how `patch-file` is handling requests.
- If there is no `If-Match`
  - Make the modifications to file (at this point we already know the file exists)
-  If `If-Match` is provided.
  - If the ETags match
    - Make the modifications
  - If the ETags do not match
    - Respond with a `409`
### Cob Spec

🎈  PatchWithEtag 🎈 

![image](https://cloud.githubusercontent.com/assets/4121849/18295046/c264dde0-7463-11e6-871f-52267a553383.png)
