### PR TITLE
Redirects

### DIFF
--- a/spec/http_clj/app/cob_spec/handlers_spec.clj
+++ b/spec/http_clj/app/cob_spec/handlers_spec.clj
@@ -68,5 +68,12 @@
     (it "responds with the parameters formatted in the body"
       (let [request {:query-params {"parameter-1" "a"
                                     "parameter-2" "b"}}]
-        (should-contain "parameter-1 = a\n"(:body (parameters request)))
-        (should-contain "parameter-2 = b"(:body (parameters request)))))))
+        (should-contain "parameter-1 = a\n" (:body (parameters request)))
+        (should-contain "parameter-2 = b" (:body (parameters request))))))
+
+  (context "redirect-to-root"
+    (it "redirects to the root"
+      (let [request {:headers {:host "host:port"}}
+            resp (redirect-to-root request)]
+        (should= 302 (:status resp))
+        (should= "http://host:port/" (get-in resp [:headers :location]))))))

--- a/spec/http_clj/app/cob_spec_spec.clj
+++ b/spec/http_clj/app/cob_spec_spec.clj
@@ -1,4 +1,5 @@
-(ns http-clj.app.cob-spec-spec (:require [speclj.core :refer :all]
+(ns http-clj.app.cob-spec-spec
+  (:require [speclj.core :refer :all]
             [clj-http.client :as client]
             [http-clj.server :as s]
             [http-clj.file :as file]
@@ -96,4 +97,9 @@
     (let [resp (client/get
                  (str root "/parameters")
                  {:query-params {"key" "value"}})]
-      (should= "key = value" (:body resp)))))
+      (should= "key = value" (:body resp))))
+
+  (it "redirects /redirect to /"
+    (let [resp (client/get (str root "/redirect"))]
+      (should= [(str root "/redirect") (str root "/")]
+               (:trace-redirects resp)))))

--- a/spec/http_clj/request/parser/headers_spec.clj
+++ b/spec/http_clj/request/parser/headers_spec.clj
@@ -11,6 +11,10 @@
       (should= {:host "www.example.com" :user-agent "Test-request"}
                (headers/parse ["Host: www.example.com" "User-Agent: Test-request"])))
 
+    (it "splits the field-name and field-value on the first colon"
+      (should= {:host "localhost:5000"}
+               (headers/parse ["Host: localhost:5000"])))
+
     (it "parses the header field values"
       (should= {:content-length 10}
                (headers/parse ["Content-Length: 10"]))))

--- a/spec/http_clj/request_handler_spec.clj
+++ b/spec/http_clj/request_handler_spec.clj
@@ -68,4 +68,12 @@
             handler (handler/auth @handler "admin" "password")
             resp (handler {:headers {:authorization (str "Basic " credentials)}})]
         (should= 200 (:status resp))
-        (should= "Welcome" (:body resp))))))
+        (should= "Welcome" (:body resp)))))
+
+  (context "redirect"
+    (it "responds with a 302 status code"
+      (should= 302 (:status (handler/redirect {} "/"))))
+
+    (it "has a location header"
+      (let [resp (handler/redirect {} "/path")]
+        (should= "/path" (get-in resp [:headers :location]))))))

--- a/src/http_clj/app/cob_spec.clj
+++ b/src/http_clj/app/cob_spec.clj
@@ -20,6 +20,7 @@
        (POST "/form" #(handlers/submit-form % form-cache))
        (GET "/form" #(handlers/last-submission % form-cache))
        (GET "/parameters" handlers/parameters)
+       (GET "/redirect" handlers/redirect-to-root)
        (OPTIONS "/method_options" (handlers/options "GET" "HEAD" "POST" "OPTIONS" "PUT"))
        (OPTIONS "/method_options2" (handlers/options "GET" "OPTIONS"))
        (GET #"^/.*$" #(handlers/static % directory))

--- a/src/http_clj/app/cob_spec/handlers.clj
+++ b/src/http_clj/app/cob_spec/handlers.clj
@@ -40,3 +40,7 @@
 
 (defn parameters [{:keys [query-params] :as request}]
   (response/create request (present-query-params query-params)))
+
+(defn redirect-to-root [request]
+  (let [host (get-in request [:headers :host])]
+    (handler/redirect request (str "http://" host "/"))))

--- a/src/http_clj/request/parser/headers.clj
+++ b/src/http_clj/request/parser/headers.clj
@@ -7,8 +7,17 @@
 (defn- field-name->keyword [[field-name field-value]]
   [(keyword field-name) field-value])
 
+(defn- filter-matching-groups [matches]
+  (drop 1 matches))
+
+(defn- trim-name-and-value [header]
+  (map string/trim header))
+
 (defn- split-header [header]
-  (map string/trim (string/split header #":")))
+    (->> header
+        (re-find #"^(.*?):(.*?)$")
+        filter-matching-groups
+        trim-name-and-value))
 
 (defn- parse-field-name:field-value [header]
   (-> header

--- a/src/http_clj/request_handler.clj
+++ b/src/http_clj/request_handler.clj
@@ -39,3 +39,6 @@
 
 (defn method-not-allowed [request]
   (response/create request "Method Not Allowed" :status 405))
+
+(defn redirect [request location]
+  (response/create request "" :status 302 :headers {:location location}))


### PR DESCRIPTION
I added a generic `redirect` function which will simply return a `302` response with the location that is provided. From there I added a cob-spec handler that will pull the `Host` from the request and redirect to `http://<host of request>/`.

In the process, I discovered a bug in the request parsing. Previously, everything after and including the second colon in a header was being discarded. This is because headers we being split using

``` clojure
(clojure.string/split header #":")
```

From there, the first two elements were used to create the key value in the `:headers` map. 

I updated this to split only on the first colon. Now the parser is using

``` clojure
(re-find #"^(.*?):(.*?)$" header)
```
### Cob Spec

![image](https://cloud.githubusercontent.com/assets/4121849/18331610/d97d75ce-7525-11e6-8ee7-fd20849385d7.png)
