### PR TITLE
Cookie Handling

### DIFF
--- a/spec/http_clj/app/cob_spec/handlers_spec.clj
+++ b/spec/http_clj/app/cob_spec/handlers_spec.clj
@@ -119,14 +119,15 @@
 
       (it "sets the cookie using the type parameters"
         (let [request {:query-params {"type" "Gingerbread"}}]
-          (should= "type=Gingerbread"
+          (should= [ "type=Gingerbread"]
                    (get-in (cookie request) [:headers :set-cookie])))
 
         (let [request {:query-params {"type" "Sugar"}}]
-          (should= "type=Sugar"
+          (should= ["type=Sugar"]
                    (get-in (cookie request) [:headers :set-cookie]))))
+
       (it "does not have a Set-Cookie header if the type param is not included"
-        (should-not-contain :set-cookie (:headers (cookie {})))))
+        (should-be empty? (:headers (cookie {})))))
 
     (describe "eat-cookie"
       (it "responds with 200"

--- a/spec/http_clj/app/cob_spec/handlers_spec.clj
+++ b/spec/http_clj/app/cob_spec/handlers_spec.clj
@@ -107,4 +107,34 @@
       (let [request {:headers {:host "host:port"}}
             resp (redirect-to-root request)]
         (should= 302 (:status resp))
-        (should= "http://host:port/" (get-in resp [:headers :location]))))))
+        (should= "http://host:port/" (get-in resp [:headers :location])))))
+
+  (context "cookie data"
+    (describe "cookie"
+      (it "responds with 200"
+        (should= 200 (:status (cookie {}))))
+
+      (it "has 'Eat' in the body"
+        (should= "Eat" (:body (cookie {}))))
+
+      (it "sets the cookie using the type parameters"
+        (let [request {:query-params {"type" "Gingerbread"}}]
+          (should= "type=Gingerbread"
+                   (get-in (cookie request) [:headers :set-cookie])))
+
+        (let [request {:query-params {"type" "Sugar"}}]
+          (should= "type=Sugar"
+                   (get-in (cookie request) [:headers :set-cookie]))))
+      (it "does not have a Set-Cookie header if the type param is not included"
+        (should-not-contain :set-cookie (:headers (cookie {})))))
+
+    (describe "eat-cookie"
+      (it "responds with 200"
+        (should= 200 (:status (eat-cookie {}))))
+
+      (it "uses the type key from the cookie to create the body"
+        (let [request {:headers {:cookie {:type "sugar"}}}]
+          (should= "mmmm sugar" (:body (eat-cookie request))))
+
+        (let [request {:headers {:cookie {:type "chocolate"}}}]
+          (should= "mmmm chocolate" (:body (eat-cookie request))))))))

--- a/spec/http_clj/app/cob_spec_spec.clj
+++ b/spec/http_clj/app/cob_spec_spec.clj
@@ -114,6 +114,24 @@
     (it "responds with 200"
       (should= 200 (:status (client/get (str root "/tea"))))))
 
+  (describe "/cookie"
+    (it "responds with 200"
+      (should= 200 (:status (client/get (str root "/cookie")))))
+
+    (it "has Eat in the body"
+      (should= "Eat" (:body (client/get (str root "/cookie"))))))
+
+  (describe "/eat_cookie"
+    (it "responds with 200"
+      (let [resp (client/get (str root "/eat_cookie")
+                             {:headers {:cookie "type=chocolate"}})]
+        (should= 200 (:status resp))))
+
+    (it "has the type cookie value in the body"
+      (let [resp (client/get (str root "/eat_cookie")
+                             {:headers {:cookie "type=chocolate"}})]
+        (should= "mmmm chocolate" (:body resp)))))
+
   (it "shows the options at /method_options"
     (let [headers (:headers (OPTIONS "/method_options"))]
       (should= "GET,HEAD,POST,OPTIONS,PUT"(get headers "Allow"))))

--- a/spec/http_clj/request/parser/headers_spec.clj
+++ b/spec/http_clj/request/parser/headers_spec.clj
@@ -29,4 +29,10 @@
       (should= {:range {:units "bytes" :start 0 :end 4}}
                (headers/parse-field-values {:range "bytes=0-4"}))
       (should= {:range {:units "bytes" :start nil :end 60}}
-               (headers/parse-field-values {:range "bytes=-60"})))))
+               (headers/parse-field-values {:range "bytes=-60"})))
+
+    (it "parses Cookie"
+      (should= {:cookie {:key "value"}}
+               (headers/parse-field-values {:cookie "key=value"}))
+      (should= {:cookie {:key "value" :token "abc123"}}
+               (headers/parse-field-values {:cookie "key=value; token=abc123"})))))

--- a/spec/http_clj/response/cookies_spec.clj
+++ b/spec/http_clj/response/cookies_spec.clj
@@ -1,0 +1,29 @@
+(ns http-clj.response.cookies-spec
+  (:require [speclj.core :refer :all]
+            [http-clj.response.cookies :as cookies]))
+
+(describe "response.cookies"
+  (describe "set-cookie"
+    (it "adds the 'Set-Cookie' header to the response"
+      (let [response {:headers {}}]
+        (should-contain :set-cookie
+                        (:headers (cookies/set-cookie response "key" "value")))))
+
+    (it "adds a key value pair to the set-cookie header"
+      (let [response {:headers {}}
+            response (cookies/set-cookie response "name" "value")]
+
+        (should= ["name=value"]
+                 (get-in response [:headers :set-cookie]))))
+
+    (it "updates the vector"
+      (let [response (-> {:headers {:set-cookie ["name=value"]}}
+                         (cookies/set-cookie "token" "abc123"))]
+
+        (should= ["name=value" "token=abc123"]
+                 (get-in response [:headers :set-cookie])))))
+
+  (describe "format-cookie"
+    (it "formats the pair into a string delimited by an equal sign"
+      (should= "name=value" (cookies/format-cookie "name" "value"))
+      (should= "token=abc123" (cookies/format-cookie "token" "abc123")))))

--- a/spec/http_clj/response/formatter_spec.clj
+++ b/spec/http_clj/response/formatter_spec.clj
@@ -12,7 +12,21 @@
   (first (string/split (byte-array->string message) #"\r\n")))
 
 (describe "response.formatter"
-  (context "format-message"
+  (describe "format-headers"
+    (it "formats a simple header"
+      (let [headers {:host "www.example.com"
+                     :content-type "text/html"}
+            expected (str "host: www.example.com\r\n"
+                          "content-type: text/html\r\n")]
+        (should= expected (format-headers headers))))
+
+    (it "formats headers that should appear multiple times"
+      (let [headers {:set-cookie ["key=value" "token=abc123"]}
+            expected (str "set-cookie: key=value\r\n"
+                          "set-cookie: token=abc123\r\n")]
+        (should= expected (format-headers headers)))))
+
+  (describe "format-message"
     (with request {:conn (mock/connection)})
 
     (it "is a valid HTTP response"

--- a/src/http_clj/app/cob_spec.clj
+++ b/src/http_clj/app/cob_spec.clj
@@ -20,6 +20,8 @@
        (GET "/logs"  (auth  #(handlers/log % log) "admin" "hunter2"))
        (GET "/coffee" handlers/no-coffee)
        (GET "/tea" handlers/tea)
+       (GET "/cookie" handlers/cookie)
+       (GET "/eat_cookie" handlers/eat-cookie)
        (POST "/form" #(handlers/submit-form % form-cache))
        (PUT "/form" #(handlers/submit-form % form-cache))
        (DELETE "/form" #(handlers/clear-submission % form-cache))

--- a/src/http_clj/app/cob_spec/handlers.clj
+++ b/src/http_clj/app/cob_spec/handlers.clj
@@ -54,3 +54,22 @@
 (defn redirect-to-root [request]
   (let [host (get-in request [:headers :host])]
     (handler/redirect request (str "http://" host "/"))))
+
+(defn- generate-cookie-headers [query-params]
+  (if-let [-type (get query-params "type")]
+    {:set-cookie (str "type=" -type)}
+    {}))
+
+(defn cookie [{:keys [query-params] :as request}]
+  (response/create
+    request
+    "Eat"
+    :headers (generate-cookie-headers query-params)))
+
+(defn- present-cookie [{headers :headers}]
+  (if-let [-type (get-in headers [:cookie :type])]
+    (str "mmmm " -type)
+    ""))
+
+(defn eat-cookie [request]
+  (response/create request (present-cookie request)))

--- a/src/http_clj/app/cob_spec/handlers.clj
+++ b/src/http_clj/app/cob_spec/handlers.clj
@@ -3,6 +3,7 @@
             [http-clj.request-handler.filesystem :as filesystem]
             [http-clj.file :as file-helper]
             [http-clj.response :as response]
+            [http-clj.response.cookies :as cookies]
             [clojure.core.match :refer [match]]
             [clojure.string :as string]))
 
@@ -55,16 +56,16 @@
   (let [host (get-in request [:headers :host])]
     (handler/redirect request (str "http://" host "/"))))
 
-(defn- generate-cookie-headers [query-params]
-  (if-let [-type (get query-params "type")]
-    {:set-cookie (str "type=" -type)}
-    {}))
+(defn- maybe-set-cookie-type [response cookie-type]
+  (if cookie-type
+    (cookies/set-cookie response "type" cookie-type)
+    response))
 
 (defn cookie [{:keys [query-params] :as request}]
-  (response/create
-    request
-    "Eat"
-    :headers (generate-cookie-headers query-params)))
+  (let [cookie-type (get query-params "type")]
+    (-> request
+      (response/create "Eat")
+      (maybe-set-cookie-type cookie-type))))
 
 (defn- present-cookie [{headers :headers}]
   (if-let [-type (get-in headers [:cookie :type])]

--- a/src/http_clj/request/parser/headers.clj
+++ b/src/http_clj/request/parser/headers.clj
@@ -47,6 +47,20 @@
       to-range-map
       parse-start-end))
 
+(defn- parse-cookie-pair [pair]
+  (-> pair
+    (string/split #"=")
+    field-name->keyword
+    (into {})))
+
+(defn- parse-cookie-pairs [pairs]
+  (into {} (map parse-cookie-pair pairs)))
+
+(defn- parse-cookie [field-value]
+  (-> field-value
+      (string/split #"; ")
+      (parse-cookie-pairs)))
+
 (defn parse-field-value [headers field-name parser]
   (if-let [field-value (field-name headers)]
     (update headers field-name parser)
@@ -55,7 +69,8 @@
 (defn parse-field-values [headers]
   (-> headers
       (parse-field-value :content-length #(Integer/parseInt %))
-      (parse-field-value :range parse-range)))
+      (parse-field-value :range parse-range)
+      (parse-field-value :cookie parse-cookie)))
 
 (defn parse [headers]
   (->> headers

--- a/src/http_clj/response/cookies.clj
+++ b/src/http_clj/response/cookies.clj
@@ -1,0 +1,11 @@
+(ns http-clj.response.cookies
+  (:require [clojure.string :as string]))
+
+(defn format-cookie [name value]
+  (str name "=" value))
+
+(defn update-cookies [cookies name value]
+  (conj cookies (format-cookie name value)))
+
+(defn set-cookie [response name value]
+  (update-in response [:headers :set-cookie] #(update-cookies % name value)))

--- a/src/http_clj/response/formatter.clj
+++ b/src/http_clj/response/formatter.clj
@@ -13,10 +13,19 @@
 (defn- to-byte-array [string]
   (byte-array (map (comp byte int) string)))
 
-(defn- format-header [[field-name field-value]]
+(defmulti format-header
+  (fn [[_ field-value]]
+    (type field-value)))
+
+(defmethod format-header String
+  [[field-name field-value]]
   (str (name field-name) ": " field-value CRLF))
 
-(defn- format-headers [headers]
+(defmethod format-header clojure.lang.Seqable
+  [[field-name field-values]]
+  (apply str (map #(format-header [field-name %]) field-values)))
+
+(defn format-headers [headers]
   (apply str (map format-header headers)))
 
 (defn- generate-status-line [status]


### PR DESCRIPTION
This updates the request parser so the `Cookie` header is now being parsed into a map. Routes and handlers for `/cookie` and `/eat_cookie` were also added to pass the proposed cookie handling test. 

Because it is possible to have multiple `Set-Cookie` headers the response, I have update the response formatter to be able to format a header that has  a list of field values or a single field-value.

8thlight/cob_spec#37

![image](https://cloud.githubusercontent.com/assets/4121849/18447937/5b3fb98e-78ee-11e6-9421-9d44dde98630.png)
