### PR TITLE
Content-Type headers for static files

### DIFF
--- a/spec/http_clj/app/cob_spec_spec.clj
+++ b/spec/http_clj/app/cob_spec_spec.clj
@@ -48,36 +48,31 @@
   (before-all (reset! thread (start-server app 5000)))
   (after-all (shutdown-server @thread))
 
-  (describe "static files"
-    (context "/"
+  (describe "/ (static files)"
     (it "displays the directory contents"
       (let [{status :status body :body} (GET "/")]
         (should= 200 status)
         (should-contain "file.txt" body)
-        (should-contain "image.gif" body)))))
+        (should-contain "image.gif" body)))
 
-  (it "will attempt to patch a static file"
-    (let [resp (client/patch
-                 "http:localhost:5000/file.txt"
-                 {:headers {:if-match "incorrect-etag"}
-                  :throw-exceptions false})]
-      (should= 409 (:status resp))))
+    (it "will attempt to patch a file"
+      (let [resp (client/patch
+                   "http:localhost:5000/file.txt"
+                   {:headers {:if-match "incorrect-etag"}
+                    :throw-exceptions false})]
+        (should= 409 (:status resp))))
 
-  (describe "/image.gif"
-    (with response (client/get (str root "/image.gif")))
+    (it "has a Content-Type header"
+      (let [response (client/get (str root "/image.gif"))]
+        (should= "image/gif" (get-in response [:headers :content-type]))))
 
-    (it "responds with 200"
-      (should= 200 (:status @response)))
+    (it "accepts range requests"
+      (let [resp (client/get "http://localhost:5000/file.txt"
+                             {:headers {:range "bytes=0-4"}})]
+        (should= 206 (:status resp)))))
 
-    (it "has a Content-Type header of image/gif"
-      (should= "image/gif" (get-in @response [:headers :content-type]))))
-
-  (it "can get partial contents of file.txt"
-    (let [resp (client/get "http://localhost:5000/file.txt"
-                           {:headers {:range "bytes=0-4"}})]
-      (should= 206 (:status resp))))
-
-  (it "has a viewable log when authenticated"
+  (describe "/logs"
+    (it "has a viewable log when authenticated"
     (let [response (client/get
                      "http://localhost:5000/logs"
                      {:basic-auth ["admin" "hunter2"]})]
@@ -85,7 +80,7 @@
 
   (it "unauthorized access to the log is not allowed"
     (let [response (GET "/logs")]
-      (should= 401 (:status response))))
+      (should= 401 (:status response)))))
 
   (describe "/form"
     (it "accepts POST requests"
@@ -141,21 +136,24 @@
                              {:headers {:cookie "type=chocolate"}})]
         (should= "mmmm chocolate" (:body resp)))))
 
-  (it "shows the options at /method_options"
+  (describe "/method_options*"
+    (it "shows the options at /method_options"
     (let [headers (:headers (OPTIONS "/method_options"))]
       (should= "GET,HEAD,POST,OPTIONS,PUT"(get headers "Allow"))))
 
   (it "shows the options at /method_options2"
     (let [headers (:headers (OPTIONS "/method_options2"))]
-      (should= "GET,OPTIONS" (get headers "Allow"))))
+      (should= "GET,OPTIONS" (get headers "Allow")))))
 
-  (it "presents the decoded and formatted query parameters"
+  (describe "/parameters"
+    (it "presents the decoded and formatted query parameters"
     (let [resp (client/get
                  (str root "/parameters")
                  {:query-params {"key" "value"}})]
-      (should= "key = value" (:body resp))))
+      (should= "key = value" (:body resp)))))
 
-  (it "redirects /redirect to /"
+  (describe "/redirect"
+    (it "redirects /redirect to /"
     (let [resp (client/get (str root "/redirect"))]
       (should= [(str root "/redirect") (str root "/")]
-               (:trace-redirects resp)))))
+               (:trace-redirects resp))))))

--- a/spec/http_clj/file_spec.clj
+++ b/spec/http_clj/file_spec.clj
@@ -3,7 +3,6 @@
             [http-clj.file :as file]))
 
 (describe "file"
-  (tags "file")
   (with test-path "/tmp/http-clj-test-file")
   (before (spit @test-path ""))
 
@@ -37,6 +36,11 @@
     (it "raises an exception if offset is outside of the length of the file"
       (should-throw clojure.lang.ExceptionInfo
                     (file/binary-slurp-range @test-path 0 5000))))
+
+  (describe "content-type-of"
+    (it "it determines the content type of the file"
+      (should= "text/plain" (file/content-type-of "file.txt"))
+      (should= "image/gif" (file/content-type-of "image.gif"))))
 
   (context "resolve"
     (it "takes two paths"

--- a/spec/http_clj/request_handler/filesystem_spec.clj
+++ b/spec/http_clj/request_handler/filesystem_spec.clj
@@ -47,6 +47,11 @@
               resp (handler/partial-file request @test-path)]
           (should= 206 (:status resp))))
 
+      (it "has the content type of the file"
+        (let [request {:headers {:range {:start 0 :end 0}}}
+              resp (handler/partial-file request @test-path)]
+          (should= "text/plain" (get-in resp [:headers :content-type]))))
+
       (it "it has the requested range in the body"
         (let [request {:headers {:range {:start 0 :end 3}}}
               resp (handler/partial-file request @test-path)]

--- a/spec/http_clj/response/formatter_spec.clj
+++ b/spec/http_clj/response/formatter_spec.clj
@@ -24,7 +24,10 @@
       (let [headers {:set-cookie ["key=value" "token=abc123"]}
             expected (str "set-cookie: key=value\r\n"
                           "set-cookie: token=abc123\r\n")]
-        (should= expected (format-headers headers)))))
+        (should= expected (format-headers headers))))
+
+    (it "treats headers as simple headers by default"
+      (should= "content-type: \r\n" (format-headers {:content-type nil}))))
 
   (describe "format-message"
     (with request {:conn (mock/connection)})

--- a/spec/http_clj/response/helpers_spec.clj
+++ b/spec/http_clj/response/helpers_spec.clj
@@ -1,0 +1,12 @@
+(ns http-clj.response.helpers-spec
+  (:require [speclj.core :refer :all]
+            [http-clj.response.helpers :as helpers]))
+
+(describe "response.helpers"
+  (describe "assoc-content-type"
+    (it "adds the content-type to the response"
+      (should= {:headers {:content-type "image/gif"}}
+               (helpers/add-content-type {} "image.gif")))
+
+    (it "does not add the header if the mimetype can not be determined"
+      (should= {} (helpers/add-content-type {} "file")))))

--- a/src/http_clj/file.clj
+++ b/src/http_clj/file.clj
@@ -2,7 +2,8 @@
   (:require [clojure.java.io :as io])
   (:import java.io.File
            java.nio.file.Files
-           java.nio.file.Paths))
+           java.nio.file.Paths
+           java.net.URLConnection))
 
 (defn binary-slurp [path]
   (-> path
@@ -42,6 +43,9 @@
   (when (not (valid-range? path start end))
     (throw (ex-info "Range Unsatisfiable" {:cause :unsatisfiable})))
   (-binary-slurp-range path start end))
+
+(defn content-type-of [path]
+  (URLConnection/guessContentTypeFromName path))
 
 (defn resolve [root-dir path]
   (-> (Paths/get root-dir (into-array [path]))

--- a/src/http_clj/request_handler/filesystem.clj
+++ b/src/http_clj/request_handler/filesystem.clj
@@ -14,9 +14,24 @@
 (defn partial-file [request path]
   (let [{start :start end :end} (get-in request [:headers :range])]
     (try
-      (response/create request (f/binary-slurp-range path start end) :status 206)
+      (response/create
+        request
+        (f/binary-slurp-range path start end)
+        :status 206
+        :headers {:content-type (f/content-type-of path)})
       (catch clojure.lang.ExceptionInfo e
         (response/create request "" :status 416)))))
+
+(defn -file [request path]
+  (response/create
+    request
+    (f/binary-slurp path)
+    :headers {:content-type (f/content-type-of path)}))
+
+(defn file [{:keys [headers] :as request} path]
+  (if (not-empty (:range headers))
+      (partial-file request path)
+      (-file request path)))
 
 (defn- -patch-file [request file]
   (with-open [stream (clojure.java.io/output-stream file)]
@@ -34,9 +49,3 @@
     (cond (nil? precondition) (-patch-file request file)
           (if-match? precondition file) (-patch-file request file)
           :else (conflict request))))
-
-(defn file [{:keys [headers] :as request} path]
-  (if (not-empty (:range headers))
-      (partial-file request path)
-      (response/create request (f/binary-slurp path)
-                       :headers {:content-type (f/content-type-of path)})))

--- a/src/http_clj/request_handler/filesystem.clj
+++ b/src/http_clj/request_handler/filesystem.clj
@@ -38,4 +38,5 @@
 (defn file [{:keys [headers] :as request} path]
   (if (not-empty (:range headers))
       (partial-file request path)
-      (response/create request (f/binary-slurp path))))
+      (response/create request (f/binary-slurp path)
+                       :headers {:content-type (f/content-type-of path)})))

--- a/src/http_clj/response/formatter.clj
+++ b/src/http_clj/response/formatter.clj
@@ -17,13 +17,13 @@
   (fn [[_ field-value]]
     (type field-value)))
 
-(defmethod format-header String
-  [[field-name field-value]]
-  (str (name field-name) ": " field-value CRLF))
-
 (defmethod format-header clojure.lang.Seqable
   [[field-name field-values]]
   (apply str (map #(format-header [field-name %]) field-values)))
+
+(defmethod format-header :default
+  [[field-name field-value]]
+  (str (name field-name) ": " field-value CRLF))
 
 (defn format-headers [headers]
   (apply str (map format-header headers)))

--- a/src/http_clj/response/helpers.clj
+++ b/src/http_clj/response/helpers.clj
@@ -1,0 +1,7 @@
+(ns http-clj.response.helpers
+  (:require [http-clj.file :as file]))
+
+(defn add-content-type [resp path]
+  (if-let [content-type (file/content-type-of path)]
+    (assoc-in resp [:headers :content-type] content-type)
+    resp))


### PR DESCRIPTION
This updates the filesystem request handlers to include the content type of the file being served. Initially, I tried to use `java.nio.file.Files/probeContentType` to get the encoded content type, but I did not have much success. Instead, this uses `java.net.URLConnection` to "guess" the content type using the name of the file.

8thlight/cob_spec#38

![image](https://cloud.githubusercontent.com/assets/4121849/18479521/fb896ae6-799a-11e6-997c-aab9766aa4bf.png)
