### PR TITLE
Content-Range headers

### DIFF
--- a/spec/http_clj/file_spec.clj
+++ b/spec/http_clj/file_spec.clj
@@ -18,20 +18,20 @@
                (seq (file/binary-slurp @test-path)))))
 
   (describe "query-file-range"
-    (before (spit @test-path "Read a range of bytes"))
+    (before (spit @test-path "Query a range of bytes"))
 
     (it "can read the first 4 bytes of a file"
-      (let [range-info (file/query-range @test-path 0 3)]
-        (should= "Read" (String. (:range range-info)))))
+      (let [range-info (file/query-range @test-path 0 4)]
+        (should= "Query" (String. (:range range-info)))))
 
     (it "can read bytes 1 through 4 of the file"
-      (let [range-info (file/query-range @test-path 1 4)]
-        (should= "ead " (String. (:range range-info)))))
+      (let [range-info (file/query-range @test-path 1 5)]
+        (should= "uery " (String. (:range range-info)))))
 
     (it "raises an exception if offset is outside of the length of the file"
       (should-throw clojure.lang.ExceptionInfo
                     (file/query-range @test-path 0 5000))
-      (should= {:cause :unsatisfiable :length 21}
+      (should= {:cause :unsatisfiable :length 22}
                (try (file/query-range @test-path 0 5000)
                     (catch Exception e
                       (ex-data e)))))
@@ -53,20 +53,20 @@
 
     (it "accepts a nil start position"
       (let [range-info (file/query-range @test-path nil 3)]
-        (should= {:start 18 :end 20 :length 21} (dissoc range-info :range))
+        (should= {:start 19 :end 21 :length 22} (dissoc range-info :range))
         (should= "tes" (String. (:range range-info))))
 
       (let [range-info (file/query-range @test-path nil 5)]
-        (should= {:start 16 :end 20 :length 21} (dissoc range-info :range))
+        (should= {:start 17 :end 21 :length 22} (dissoc range-info :range))
         (should= "bytes" (String. (:range range-info)))))
 
     (it "accepts a nil end position"
-      (let [range-info (file/query-range @test-path 5 nil)]
-        (should= {:start 5 :end 20 :length 21} (dissoc range-info :range))
+      (let [range-info (file/query-range @test-path 6 nil)]
+        (should= {:start 6 :end 21 :length 22} (dissoc range-info :range))
         (should= "a range of bytes" (String. (:range range-info))))
 
-      (let [range-info (file/query-range @test-path 16 nil)]
-        (should= {:start 16 :end 20 :length 21} (dissoc range-info :range))
+      (let [range-info (file/query-range @test-path 17 nil)]
+        (should= {:start 17 :end 21 :length 22} (dissoc range-info :range))
         (should= "bytes" (String. (:range range-info))))))
 
   (context "binary-slurp-range"

--- a/spec/http_clj/file_spec.clj
+++ b/spec/http_clj/file_spec.clj
@@ -1,6 +1,7 @@
 (ns http-clj.file-spec
   (:require [speclj.core :refer :all]
-            [http-clj.file :as file]))
+            [http-clj.file :as file]
+            [clojure.java.io :as io]))
 
 (describe "file"
   (with test-path "/tmp/http-clj-test-file")
@@ -14,6 +15,54 @@
       (should= (seq (.getBytes @contents))
                (seq (file/binary-slurp @test-path)))))
 
+  (describe "query-file-range"
+    (before (spit @test-path "Read a range of bytes"))
+
+    (it "can read the first 4 bytes of a file"
+      (let [range-info (file/query-range @test-path 0 3)]
+        (should= "Read" (String. (:range range-info)))))
+
+    (it "can read bytes 1 through 4 of the file"
+      (let [range-info (file/query-range @test-path 1 4)]
+        (should= "ead " (String. (:range range-info)))))
+
+    (it "raises an exception if offset is outside of the length of the file"
+      (should-throw clojure.lang.ExceptionInfo
+                    (file/query-range @test-path 0 5000)))
+
+    (it "determines the length of the file"
+      (spit @test-path "a")
+      (should= 1 (:length (file/query-range @test-path 0 0)))
+
+      (spit @test-path "abcdefg")
+      (should= 7 (:length (file/query-range @test-path 0 0))))
+
+    (it "has the start position of the range"
+      (should= 0 (:start (file/query-range @test-path 0 3)))
+      (should= 4 (:start (file/query-range @test-path 4 6))))
+
+    (it "has the end position of the range"
+      (should= 3 (:end (file/query-range @test-path 0 3)))
+      (should= 6 (:end (file/query-range @test-path 4 6))))
+
+    (it "accepts a nil start position"
+      (let [range-info (file/query-range @test-path nil 3)]
+        (should= {:start 18 :end 20 :length 21} (dissoc range-info :range))
+        (should= "tes" (String. (:range range-info))))
+
+      (let [range-info (file/query-range @test-path nil 5)]
+        (should= {:start 16 :end 20 :length 21} (dissoc range-info :range))
+        (should= "bytes" (String. (:range range-info)))))
+
+    (it "accepts a nil end position"
+      (let [range-info (file/query-range @test-path 5 nil)]
+        (should= {:start 5 :end 20 :length 21} (dissoc range-info :range))
+        (should= "a range of bytes" (String. (:range range-info))))
+
+      (let [range-info (file/query-range @test-path 16 nil)]
+        (should= {:start 16 :end 20 :length 21} (dissoc range-info :range))
+        (should= "bytes" (String. (:range range-info))))))
+
   (context "binary-slurp-range"
     (before (spit @test-path "Read a range of bytes"))
 
@@ -24,14 +73,6 @@
     (it "can read bytes 1 through 4 of the file"
       (let [byte-range (file/binary-slurp-range @test-path 1 4)]
         (should= "ead " (String. byte-range))))
-
-    (it "reads the last n bytes when start is nil"
-      (let [byte-range (file/binary-slurp-range @test-path nil 5)]
-        (should= "bytes" (String. byte-range))))
-
-    (it "reads the last n bytes when end is nil"
-      (let [byte-range (file/binary-slurp-range @test-path 5 nil)]
-        (should= "a range of bytes" (String. byte-range))))
 
     (it "raises an exception if offset is outside of the length of the file"
       (should-throw clojure.lang.ExceptionInfo

--- a/spec/http_clj/request_handler/filesystem_spec.clj
+++ b/spec/http_clj/request_handler/filesystem_spec.clj
@@ -52,7 +52,7 @@
               resp (handler/partial-file request @test-path)]
           (should= "text/plain" (get-in resp [:headers :content-type]))))
 
-      (it "it has the requested range in the body"
+      (it "has the requested range in the body"
         (let [request {:headers {:range {:start 0 :end 3}}}
               resp (handler/partial-file request @test-path)]
           (should= "Some" (String. (:body resp))))
@@ -60,6 +60,15 @@
         (let [request {:headers {:range {:start 1 :end 3}}}
               resp (handler/partial-file request @test-path)]
           (should= "ome" (String. (:body resp)))))
+
+      (it "has a Content-Range header"
+        (let [request {:headers {:range {:start 0 :end 3}}}
+              resp (handler/partial-file request @test-path)]
+          (should= "bytes 0-3/12" (get-in resp [:headers :content-range])))
+
+        (let [request {:headers {:range {:start nil :end 3}}}
+              resp (handler/partial-file request @test-path)]
+          (should= "bytes 9-11/12" (get-in resp [:headers :content-range]))))
 
       (it "responds with a 416 if the range is not satisfiable"
         (let [request {:headers {:range {:start 1 :end 500}}}

--- a/spec/http_clj/request_handler/filesystem_spec.clj
+++ b/spec/http_clj/request_handler/filesystem_spec.clj
@@ -43,40 +43,40 @@
 
     (context "partial-file"
       (it "responds with a 206 if a range is provided"
-        (let [request {:headers {:range {:start 0 :end 0}}}
+        (let [request {:headers {:range {:units "bytes" :start 0 :end 0}}}
               resp (handler/partial-file request @test-path)]
           (should= 206 (:status resp))))
 
       (it "has the content type of the file"
-        (let [request {:headers {:range {:start 0 :end 0}}}
+        (let [request {:headers {:range {:units "bytes" :start 0 :end 0}}}
               resp (handler/partial-file request @test-path)]
           (should= "text/plain" (get-in resp [:headers :content-type]))))
 
       (it "has the requested range in the body"
-        (let [request {:headers {:range {:start 0 :end 3}}}
+        (let [request {:headers {:range {:units "bytes" :start 0 :end 3}}}
               resp (handler/partial-file request @test-path)]
           (should= "Some" (String. (:body resp))))
 
-        (let [request {:headers {:range {:start 1 :end 3}}}
+        (let [request {:headers {:range {:units "bytes" :start 1 :end 3}}}
               resp (handler/partial-file request @test-path)]
           (should= "ome" (String. (:body resp)))))
 
       (it "has a Content-Range header"
-        (let [request {:headers {:range {:start 0 :end 3}}}
+        (let [request {:headers {:range {:units "bytes" :start 0 :end 3}}}
               resp (handler/partial-file request @test-path)]
           (should= "bytes 0-3/12" (get-in resp [:headers :content-range])))
 
-        (let [request {:headers {:range {:start nil :end 3}}}
+        (let [request {:headers {:range {:units "bytes" :start nil :end 3}}}
               resp (handler/partial-file request @test-path)]
           (should= "bytes 9-11/12" (get-in resp [:headers :content-range]))))
 
       (it "responds with a 416 if the range is not satisfiable"
-        (let [request {:headers {:range {:start 1 :end 500}}}
+        (let [request {:headers {:range {:units "bytes" :start 1 :end 500}}}
               resp (handler/partial-file request @test-path)]
           (should= 416 (:status resp))))
 
       (it "includes the Content-Range when a request is not satisfiable"
-        (let [request {:headers {:range {:start 1 :end 500}}}
+        (let [request {:headers {:range {:units "bytes" :start 1 :end 500}}}
               resp (handler/partial-file request @test-path)]
           (should= "bytes */12" (get-in resp [:headers :content-range])))))
 
@@ -121,6 +121,6 @@
           (should= "text/plain" (:content-type headers))))
 
       (it "it uses partial-file if a range is provided"
-        (let [request {:headers {:range {:start 0 :end 0}}}]
+        (let [request {:headers {:range {:units "bytes" :start 0 :end 0}}}]
           (should-invoke handler/partial-file {:times 1}
                          (handler/file request @test-path)))))))

--- a/spec/http_clj/request_handler/filesystem_spec.clj
+++ b/spec/http_clj/request_handler/filesystem_spec.clj
@@ -73,7 +73,12 @@
       (it "responds with a 416 if the range is not satisfiable"
         (let [request {:headers {:range {:start 1 :end 500}}}
               resp (handler/partial-file request @test-path)]
-          (should= 416 (:status resp)))))
+          (should= 416 (:status resp))))
+
+      (it "includes the Content-Range when a request is not satisfiable"
+        (let [request {:headers {:range {:start 1 :end 500}}}
+              resp (handler/partial-file request @test-path)]
+          (should= "bytes */12" (get-in resp [:headers :content-range])))))
 
     (context "patch-file"
       (with request {:body (.getBytes "New content")})

--- a/spec/http_clj/response/headers_spec.clj
+++ b/spec/http_clj/response/headers_spec.clj
@@ -1,24 +1,24 @@
-(ns http-clj.response.helpers-spec
+(ns http-clj.response.headers-spec
   (:require [speclj.core :refer :all]
-            [http-clj.response.helpers :as helpers]))
+            [http-clj.response.headers :as headers]))
 
-(describe "response.helpers"
+(describe "response.headers"
   (describe "add-content-type"
     (it "adds the content-type to the response"
       (should= {:headers {:content-type "image/gif"}}
-               (helpers/add-content-type {} "image.gif")))
+               (headers/add-content-type {} "image.gif")))
 
     (it "does not add the header if the mimetype can not be determined"
-      (should= {} (helpers/add-content-type {} "file"))))
+      (should= {} (headers/add-content-type {} "file"))))
 
   (describe "add-content-range"
     (it "adds the content-range to the response"
       (should= {:headers {:content-range "bytes 0-3/77"}}
-               (helpers/add-content-range {} "bytes" 0 3 77))
+               (headers/add-content-range {} "bytes" 0 3 77))
 
       (should= {:headers {:content-range "chars 6-10/100"}}
-               (helpers/add-content-range {} "chars" 6 10 100)))
+               (headers/add-content-range {} "chars" 6 10 100)))
 
     (it "provides a wildcard range when only the units and length are given"
       (should= {:headers {:content-range "bytes */100"}}
-               (helpers/add-content-range {} "bytes" 100)))))
+               (headers/add-content-range {} "bytes" 100)))))

--- a/spec/http_clj/response/helpers_spec.clj
+++ b/spec/http_clj/response/helpers_spec.clj
@@ -3,10 +3,18 @@
             [http-clj.response.helpers :as helpers]))
 
 (describe "response.helpers"
-  (describe "assoc-content-type"
+  (describe "add-content-type"
     (it "adds the content-type to the response"
       (should= {:headers {:content-type "image/gif"}}
                (helpers/add-content-type {} "image.gif")))
 
     (it "does not add the header if the mimetype can not be determined"
-      (should= {} (helpers/add-content-type {} "file")))))
+      (should= {} (helpers/add-content-type {} "file"))))
+
+  (describe "add-content-range"
+    (it "adds the content-range to the response"
+      (should= {:headers {:content-range "bytes 0-3/77"}}
+               (helpers/add-content-range {} "bytes" 0 3 77))
+
+      (should= {:headers {:content-range "chars 6-10/100"}}
+               (helpers/add-content-range {} "chars" 6 10 100)))))

--- a/spec/http_clj/response/helpers_spec.clj
+++ b/spec/http_clj/response/helpers_spec.clj
@@ -17,4 +17,8 @@
                (helpers/add-content-range {} "bytes" 0 3 77))
 
       (should= {:headers {:content-range "chars 6-10/100"}}
-               (helpers/add-content-range {} "chars" 6 10 100)))))
+               (helpers/add-content-range {} "chars" 6 10 100)))
+
+    (it "provides a wildcard range when only the units and length are given"
+      (should= {:headers {:content-range "bytes */100"}}
+               (helpers/add-content-range {} "bytes" 100)))))

--- a/src/http_clj/request_handler/filesystem.clj
+++ b/src/http_clj/request_handler/filesystem.clj
@@ -18,12 +18,13 @@
     (-> request
       (response/create range :status 206)
       (headers/add-content-type path)
-      (headers/add-content-range "bytes" start end length))))
+      (headers/add-content-range units start end length))))
 
 (defn- range-unsatisfiable [request length]
-  (-> request
-      (response/create "" :status 416)
-      (headers/add-content-range "bytes" length)))
+  (let [units (get-in request [:headers :range :units])]
+    (-> request
+        (response/create "" :status 416)
+        (headers/add-content-range units length))))
 
 (defn partial-file [request path]
   (let [{start :start end :end} (get-in request [:headers :range])]

--- a/src/http_clj/request_handler/filesystem.clj
+++ b/src/http_clj/request_handler/filesystem.clj
@@ -2,7 +2,7 @@
   (:require [http-clj.file :as f]
             [clojure.java.io :as io]
             [http-clj.response :as response]
-            [http-clj.response.helpers :as helpers]
+            [http-clj.response.headers :as headers]
             [http-clj.presentation.template :as template]
             [http-clj.presentation.presenter :as presenter]
             [http-clj.entity :as entity]))
@@ -17,13 +17,13 @@
         {:keys [start end length range]} (f/query-range path start end)]
     (-> request
       (response/create range :status 206)
-      (helpers/add-content-type path)
-      (helpers/add-content-range "bytes" start end length))))
+      (headers/add-content-type path)
+      (headers/add-content-range "bytes" start end length))))
 
 (defn- range-unsatisfiable [request length]
   (-> request
       (response/create "" :status 416)
-      (helpers/add-content-range "bytes" length)))
+      (headers/add-content-range "bytes" length)))
 
 (defn partial-file [request path]
   (let [{start :start end :end} (get-in request [:headers :range])]
@@ -35,7 +35,7 @@
 (defn- -file [request path]
   (-> request
       (response/create (f/binary-slurp path))
-      (helpers/add-content-type path)))
+      (headers/add-content-type path)))
 
 (defn file [{:keys [headers] :as request} path]
   (if (not-empty (:range headers))

--- a/src/http_clj/response/headers.clj
+++ b/src/http_clj/response/headers.clj
@@ -1,4 +1,4 @@
-(ns http-clj.response.helpers
+(ns http-clj.response.headers
   (:require [http-clj.file :as file]))
 
 (defn add-content-type [resp path]

--- a/src/http_clj/response/helpers.clj
+++ b/src/http_clj/response/helpers.clj
@@ -5,3 +5,10 @@
   (if-let [content-type (file/content-type-of path)]
     (assoc-in resp [:headers :content-type] content-type)
     resp))
+
+(defn- format-content-range [units start end length]
+  (str units " " start "-" end "/" length))
+
+(defn add-content-range [resp units start end length]
+  (assoc-in resp [:headers :content-range]
+            (format-content-range units start end length)))

--- a/src/http_clj/response/helpers.clj
+++ b/src/http_clj/response/helpers.clj
@@ -9,6 +9,14 @@
 (defn- format-content-range [units start end length]
   (str units " " start "-" end "/" length))
 
-(defn add-content-range [resp units start end length]
-  (assoc-in resp [:headers :content-range]
-            (format-content-range units start end length)))
+(defn- format-wildcard-content-range [units length]
+  (str "bytes " "*/" length))
+
+(defn- -add-content-range [resp field-value]
+  (assoc-in resp [:headers :content-range] field-value))
+
+(defn add-content-range
+  ([resp units start end length]
+  (-add-content-range resp (format-content-range units start end length)))
+  ([resp units length]
+   (-add-content-range resp (format-wildcard-content-range units length))))


### PR DESCRIPTION
This updates `request-handler.filesystem/partial-file` to include the `Content-Range` header in the response.

To do this, `file/binary-slurp-range` was modified to simply extract a range from a file on disk, and a new function `file/query-range`, was created to take over some of the former responsibilities of `binary-slurp-file`, mainly to know how to respond to an empty start or end position.

This new function returns a map of the resulting query or throws an exception if the range is not satisfiable. The map looks like this

``` clojure
{:start <start position>
 :end <end position
 :length <length of the file>
 :range <the requested range of the file>}
```

This map is then used to by the `partial-file` handler to compose and attach the `Content-Range` header to the response.
## Cob Spec - Partial Content

This is a screenshot of Partial Content with the updates that are proposed in 8thlight/cob_spec#47.

<img width="591" alt="screen shot 2016-09-14 at 9 56 29 am" src="https://cloud.githubusercontent.com/assets/4121849/18520178/5f1d0d48-7a6c-11e6-906e-5cd054c48830.png">
